### PR TITLE
Small fix in set_multi if we're not given anything to store

### DIFF
--- a/bmemcached/__init__.py
+++ b/bmemcached/__init__.py
@@ -54,8 +54,9 @@ class Client(object):
 
     def set_multi(self, mappings, time=100):
         returns = []
-        for server in self.servers:
-            returns.append(server.set_multi(mappings, time))
+        if mappings:
+            for server in self.servers:
+                returns.append(server.set_multi(mappings, time))
 
         return all(returns)
 


### PR DESCRIPTION
Similar fix to get_multi was in the last pull request - this makes these two calls behave the same as the old versions in these edge cases.
