### PR TITLE
Python3 compatibility with working tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,6 @@ language: python
 python:
   - "2.6"
   - "2.7"
+  - "3.3"
 install: pip install -r requirements_test.txt --use-mirrors
 script: ./.travis-runs-tests.sh

--- a/bmemcached/__init__.py
+++ b/bmemcached/__init__.py
@@ -1,2 +1,2 @@
 __all__ = ['Client']
-from .client import Client
+from bmemcached.client import Client

--- a/bmemcached/client.py
+++ b/bmemcached/client.py
@@ -1,3 +1,4 @@
+import sys
 import logging
 from bmemcached.protocol import Protocol
 
@@ -8,10 +9,9 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
-try:
-    unicode
-except NameError:
-    unicode = str
+# Python2/3 compatibility
+if sys.version_info[0] != 2:
+    basestring = str
 
 class Client(object):
     """
@@ -44,7 +44,7 @@ class Client(object):
         :return: Returns nothing
         :rtype: None
         """
-        if isinstance(servers, (str, unicode)):
+        if isinstance(servers, basestring):
             servers = [servers]
 
         assert servers, "No memcached servers supplied"

--- a/bmemcached/client.py
+++ b/bmemcached/client.py
@@ -8,6 +8,10 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
+try:
+    unicode
+except NameError:
+    unicode = str
 
 class Client(object):
     """
@@ -40,7 +44,7 @@ class Client(object):
         :return: Returns nothing
         :rtype: None
         """
-        if isinstance(servers, basestring):
+        if isinstance(servers, (str, unicode)):
             servers = [servers]
 
         assert servers, "No memcached servers supplied"

--- a/bmemcached/protocol.py
+++ b/bmemcached/protocol.py
@@ -1,28 +1,27 @@
 import sys
-try:
-    from cPickle import dumps, loads
-except ImportError:
-    from pickle import dumps, loads
 import logging
 import re
 import socket
 import struct
-try:
-    import thread
-except ImportError:
-    import _thread as thread
 import threading
-try:
-    from urlparse import urlparse
-except ImportError:
-    from urllib.parse import urlparse
 import zlib
+
+# Python2/3 compatibility
+if sys.version_info[0] == 2:
+    import thread
+    from urlparse import urlparse
+    from cPickle import dumps, loads
+
+else:
+    long = int
+    unicode = str
+    import _thread as thread
+    from pickle import dumps, loads
+    from urllib.parse import urlparse
 
 from bmemcached.exceptions import AuthenticationNotSupported, InvalidCredentials, MemcachedException
 
-if sys.version_info[0] != 2:
-    long = int
-    unicode = str
+logger = logging.getLogger(__name__)
 
 def to_bytes(data):
     try:
@@ -30,8 +29,6 @@ def to_bytes(data):
 
     except AttributeError:
         return data
-
-logger = logging.getLogger(__name__)
 
 
 class Protocol(object):
@@ -202,7 +199,7 @@ class Protocol(object):
             raise AuthenticationNotSupported('This module only supports '
                                              'PLAIN auth for now.')
 
-        method = unicode('PLAIN').encode('ascii')
+        method = to_bytes('PLAIN')
         username = to_bytes(username)
         password = to_bytes(password)
         auth = b''.join([b'\x00', username, b'\x00', password])

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -14,7 +14,7 @@ class TestServerAuth(unittest.TestCase):
         mocked_response.return_value = (0, 0, 0, 0, 0, 0x81, 0, 0, 0, 0)
         server = bmemcached.client.Protocol('127.0.0.1')
         # can pass anything and it'll work
-        self.assertTrue(server.authenticate('user', 'badpassword'))
+        self.assertTrue(server.authenticate('user', b'badpassword'))
 
     @mock.patch.object(bmemcached.client.Protocol, '_get_response')
     def testNotUsingPlainAuth(self, mocked_response):

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -13,7 +13,7 @@ class TestMemcachedErrors(unittest.TestCase):
         client = bmemcached.Client('127.0.0.1:11211', 'user', 'password')
         with mock.patch.object(bmemcached.client.Protocol, '_get_response') as mocked_response:
             mocked_response.return_value = (0, 0, 0, 0, 0, 0x81, 0, 0, 0, 0)
-            self.assertRaises(MemcachedException, client.get, 'foo')
+            self.assertRaises(MemcachedException, client.get, b'foo')
 
     def testSet(self):
         """
@@ -23,7 +23,7 @@ class TestMemcachedErrors(unittest.TestCase):
         client = bmemcached.Client('127.0.0.1:11211', 'user', 'password')
         with mock.patch.object(bmemcached.client.Protocol, '_get_response') as mocked_response:
             mocked_response.return_value = (0, 0, 0, 0, 0, 0x81, 0, 0, 0, 0)
-            self.assertRaises(MemcachedException, client.set, 'foo', 'bar', 300)
+            self.assertRaises(MemcachedException, client.set, b'foo', b'bar', 300)
 
     def testIncrDecr(self):
         """
@@ -31,11 +31,11 @@ class TestMemcachedErrors(unittest.TestCase):
         successful.
         """
         client = bmemcached.Client('127.0.0.1:11211', 'user', 'password')
-        client.set('foo', 1)
+        client.set(b'foo', 1)
         with mock.patch.object(bmemcached.client.Protocol, '_get_response') as mocked_response:
             mocked_response.return_value = (0, 0, 0, 0, 0, 0x81, 0, 0, 0, 2)
-            self.assertRaises(MemcachedException, client.incr, 'foo', 1)
-            self.assertRaises(MemcachedException, client.decr, 'foo', 1)
+            self.assertRaises(MemcachedException, client.incr, b'foo', 1)
+            self.assertRaises(MemcachedException, client.decr, b'foo', 1)
 
     def testDelete(self):
         """
@@ -45,7 +45,7 @@ class TestMemcachedErrors(unittest.TestCase):
         client.flush_all()
         with mock.patch.object(bmemcached.client.Protocol, '_get_response') as mocked_response:
             mocked_response.return_value = (0, 0, 0, 0, 0, 0x81, 0, 0, 0, 0)
-            self.assertRaises(MemcachedException, client.delete, 'foo')
+            self.assertRaises(MemcachedException, client.delete, b'foo')
 
     def testFlushAll(self):
         """

--- a/tests/test_simple_functions.py
+++ b/tests/test_simple_functions.py
@@ -1,6 +1,7 @@
 import unittest
 import bmemcached
 
+# Python2/3 compatibility
 try:
     long
 except NameError:

--- a/tests/test_simple_functions.py
+++ b/tests/test_simple_functions.py
@@ -1,6 +1,10 @@
 import unittest
 import bmemcached
 
+try:
+    long
+except NameError:
+    long = int
 
 class MemcachedTests(unittest.TestCase):
     def setUp(self):
@@ -8,97 +12,97 @@ class MemcachedTests(unittest.TestCase):
         self.client = bmemcached.Client(self.server, 'user', 'password')
 
     def tearDown(self):
-        self.client.delete('test_key')
-        self.client.delete('test_key2')
+        self.client.delete(b'test_key')
+        self.client.delete(b'test_key2')
         self.client.disconnect_all()
 
     def testSet(self):
-        self.assertTrue(self.client.set('test_key', 'test'))
+        self.assertTrue(self.client.set(b'test_key', b'test'))
 
     def testSetMulti(self):
         self.assertTrue(self.client.set_multi({
-            'test_key': 'value',
-            'test_key2': 'value2'}))
+            b'test_key': b'value',
+            b'test_key2': b'value2'}))
 
     def testGet(self):
-        self.client.set('test_key', 'test')
-        self.assertEqual('test', self.client.get('test_key'))
+        self.client.set(b'test_key', b'test')
+        self.assertEqual(b'test', self.client.get(b'test_key'))
 
     def testGetEmptyString(self):
-        self.client.set('test_key', '')
-        self.assertEqual('', self.client.get('test_key'))
+        self.client.set(b'test_key', b'')
+        self.assertEqual(b'', self.client.get(b'test_key'))
 
     def testGetMulti(self):
         self.assertTrue(self.client.set_multi({
-            'test_key': 'value',
-            'test_key2': 'value2'
+            b'test_key': b'value',
+            b'test_key2': b'value2'
         }))
-        self.assertEqual({'test_key': 'value', 'test_key2': 'value2'},
-                         self.client.get_multi(['test_key', 'test_key2']))
-        self.assertEqual({'test_key': 'value', 'test_key2': 'value2'},
-                         self.client.get_multi(['test_key', 'test_key2', 'nothere']))
+        self.assertEqual({b'test_key': b'value', b'test_key2': b'value2'},
+                         self.client.get_multi([b'test_key', b'test_key2']))
+        self.assertEqual({b'test_key': b'value', b'test_key2': b'value2'},
+                         self.client.get_multi([b'test_key', b'test_key2', b'nothere']))
 
     def testGetLong(self):
-        self.client.set('test_key', 1L)
-        value = self.client.get('test_key')
-        self.assertEqual(1L, value)
+        self.client.set(b'test_key', long(1))
+        value = self.client.get(b'test_key')
+        self.assertEqual(long(1), value)
         self.assertTrue(isinstance(value, long))
 
     def testGetInteger(self):
-        self.client.set('test_key', 1)
-        value = self.client.get('test_key')
+        self.client.set(b'test_key', 1)
+        value = self.client.get(b'test_key')
         self.assertEqual(1, value)
         self.assertTrue(isinstance(value, int))
 
     def testGetObject(self):
-        self.client.set('test_key', {'a': 1})
-        value = self.client.get('test_key')
+        self.client.set(b'test_key', {'a': 1})
+        value = self.client.get(b'test_key')
         self.assertTrue(isinstance(value, dict))
         self.assertTrue('a' in value)
         self.assertEqual(1, value['a'])
 
     def testDelete(self):
-        self.client.set('test_key', 'test')
-        self.assertTrue(self.client.delete('test_key'))
-        self.assertEqual(None, self.client.get('test_key'))
+        self.client.set(b'test_key', b'test')
+        self.assertTrue(self.client.delete(b'test_key'))
+        self.assertEqual(None, self.client.get(b'test_key'))
 
     def testDeleteUnknownKey(self):
-        self.assertTrue(self.client.delete('test_key'))
+        self.assertTrue(self.client.delete(b'test_key'))
 
     def testAddPass(self):
-        self.assertTrue(self.client.add('test_key', 'test'))
+        self.assertTrue(self.client.add(b'test_key', b'test'))
 
     def testAddFail(self):
-        self.client.add('test_key', 'value')
-        self.assertFalse(self.client.add('test_key', 'test'))
+        self.client.add(b'test_key', b'value')
+        self.assertFalse(self.client.add(b'test_key', b'test'))
 
     def testReplacePass(self):
-        self.client.add('test_key', 'value')
-        self.assertTrue(self.client.replace('test_key', 'value2'))
-        self.assertEqual('value2', self.client.get('test_key'))
+        self.client.add(b'test_key', b'value')
+        self.assertTrue(self.client.replace(b'test_key', b'value2'))
+        self.assertEqual(b'value2', self.client.get(b'test_key'))
 
     def testReplaceFail(self):
-        self.assertFalse(self.client.replace('test_key', 'value'))
+        self.assertFalse(self.client.replace(b'test_key', b'value'))
 
     def testIncrement(self):
-        self.assertEqual(0, self.client.incr('test_key', 1))
-        self.assertEqual(1, self.client.incr('test_key', 1))
+        self.assertEqual(0, self.client.incr(b'test_key', 1))
+        self.assertEqual(1, self.client.incr(b'test_key', 1))
 
     def testDecrement(self):
-        self.assertEqual(0, self.client.decr('test_key', 1))
-        self.assertEqual(0, self.client.decr('test_key', 1))
+        self.assertEqual(0, self.client.decr(b'test_key', 1))
+        self.assertEqual(0, self.client.decr(b'test_key', 1))
 
     def testFlush(self):
-        self.client.set('test_key', 'test')
+        self.client.set(b'test_key', b'test')
         self.assertTrue(self.client.flush_all())
-        self.assertEqual(None, self.client.get('test_key'))
+        self.assertEqual(None, self.client.get(b'test_key'))
 
     def testStats(self):
         stats = self.client.stats()[self.server]
-        self.assertTrue('pid' in stats)
+        self.assertTrue(b'pid' in stats)
 
-        stats = self.client.stats('settings')[self.server]
-        self.assertTrue('verbosity' in stats)
+        stats = self.client.stats(b'settings')[self.server]
+        self.assertTrue(b'verbosity' in stats)
 
-        stats = self.client.stats('slabs')[self.server]
-        self.assertTrue('1:get_hits' in stats)
+        stats = self.client.stats(b'slabs')[self.server]
+        self.assertTrue(b'1:get_hits' in stats)


### PR DESCRIPTION
Cleaned up the code a little and removed changes to the default ttl for keys (even though I think default should be 0, this patch isn't the place for it).

Test cases are passing and things seem to be working.

Open issues: 

username and password are the only things automatically encoded (to utf-8 with surrogateescape bytes) if they are not already in a specified encoding. It may be better to force this interface to be bytes only like the rest of the code. it just seemed more natural to me to use the interface this way - and if auth fails it will be known upfront whereas other encoding issues could pass silently.

automatic unicode or bytes handling might be nice, but since we have to send memcached actual bytes we do need to worry about it and it can get complicated. for the purpose of interoperability, it would probably be better to require users provide strings encoded as bytes for keys and values to reduce the chance of different software storing and retrieving in different encodings.

speed can also be impacted if having to encode/decode everything where as if the programmer knows upfront to send bytes, the bytes can be prepared in bulk ahead of time.

another option might be to add 'encoding' and 'errors' attributes to the Client and allow the user to have some control over the handling of unicode serialization. but if you do this it might be necessary to provide arguments in every method to allow a specific override ... and then it gets complicated again.