### PR TITLE
Implement CAS.

### DIFF
--- a/bmemcached/client.py
+++ b/bmemcached/client.py
@@ -48,33 +48,61 @@ class Client(object):
         self._servers = [Protocol(server, self.username, self.password,
                                   self.compression) for server in servers]
 
-    def get(self, key):
+    def get(self, key, get_cas=False):
         """
         Get a key from server.
 
         :param key: Key's name
         :type key: basestring
+        :param get_cas: If true, return (value, cas), where cas is the new CAS value.
+        :type get_cas: boolean
         :return: Returns a key data from server.
         :rtype: object
         """
         for server in self.servers:
-            value = server.get(key)
+            value, cas = server.get(key)
             if value is not None:
-                return value
+                if get_cas:
+                    return value, cas
+                else:
+                    return value
 
-    def get_multi(self, keys):
+    def gets(self, key):
+        """
+        Get a key from server, returning the value and its CAS key.
+
+        This method is for API compatibility with other implementations.
+
+        :param key: Key's name
+        :type key: basestring
+        :return: Returns (key data, value), or (None, None) if the value is not in cache.
+        :rtype: object
+        """
+        for server in self.servers:
+            value, cas = server.get(key)
+            if value is not None:
+                return value, cas
+        return None, None
+
+    def get_multi(self, keys, get_cas=False):
         """
         Get multiple keys from server.
 
         :param keys: A list of keys to from server.
         :type keys: list
+        :param get_cas: If get_cas is true, each value is (data, cas), with each result's CAS value.
+        :type get_cas: boolean
         :return: A dict with all requested keys.
         :rtype: dict
         """
         d = {}
         if keys:
             for server in self.servers:
-                d.update(server.get_multi(keys))
+                results = server.get_multi(keys)
+                if not get_cas:
+                    for key, (value, cas) in results.items():
+                        results[key] = value
+                d.update(results)
                 keys = [_ for _ in keys if not _ in d]
                 if not keys:
                     break
@@ -96,6 +124,25 @@ class Client(object):
         returns = []
         for server in self.servers:
             returns.append(server.set(key, value, time))
+
+        return any(returns)
+
+    def cas(self, key, value, cas, time=0):
+        """
+        Set a value for a key on server if its CAS value matches cas.
+
+        :param key: Key's name
+        :type key: basestring
+        :param value: A value to be stored on server.
+        :type value: object
+        :param time: Time in seconds that your key will expire.
+        :type time: int
+        :return: True in case of success and False in case of failure
+        :rtype: bool
+        """
+        returns = []
+        for server in self.servers:
+            returns.append(server.cas(key, value, cas, time))
 
         return any(returns)
 
@@ -155,7 +202,7 @@ class Client(object):
 
         return any(returns)
 
-    def delete(self, key):
+    def delete(self, key, cas=0):
         """
         Delete a key/value from server. If key does not exist, it returns True.
 
@@ -166,7 +213,7 @@ class Client(object):
         """
         returns = []
         for server in self.servers:
-            returns.append(server.delete(key))
+            returns.append(server.delete(key, cas))
 
         return any(returns)
 

--- a/test/test_simple_functions.py
+++ b/test/test_simple_functions.py
@@ -6,13 +6,17 @@ from bmemcached.protocol import Protocol
 class MemcachedTests(unittest.TestCase):
     def setUp(self):
         self.server = '127.0.0.1:11211'
-        self.client = bmemcached.Client(self.server, 'user', 'password')
+        self.server = '/tmp/memcached.sock'
+        self.client = bmemcached.Client(self.server) #, 'user', 'password')
 
     def tearDown(self):
-        self.client.delete('test_key')
-        self.client.delete('test_key2')
+        self.reset()
         self.client.disconnect_all()
         
+    def reset(self):
+        self.client.delete('test_key')
+        self.client.delete('test_key2')
+
     def testSet(self):
         self.assertTrue(self.client.set('test_key', 'test'))
 
@@ -28,6 +32,81 @@ class MemcachedTests(unittest.TestCase):
     def testGet(self):
         self.client.set('test_key', 'test')
         self.assertEqual('test', self.client.get('test_key'))
+
+    def testCas(self):
+        value, cas = self.client.gets('nonexistant')
+        self.assertTrue(value is None)
+        self.assertTrue(cas is None)
+
+        # cas() with a cas value of None is equivalent to add.
+        self.assertTrue(self.client.cas('test_key', 'test', cas))
+        self.assertFalse(self.client.cas('test_key', 'testX', cas))
+
+        # Load the CAS key.
+        value, cas = self.client.gets('test_key')
+        self.assertEqual('test', value)
+        self.assertTrue(cas is not None)
+
+        # Overwrite test_key only if it hasn't changed since we read it.
+        self.assertTrue(self.client.cas('test_key', 'test2', cas))
+        self.assertEqual(self.client.get('test_key'), 'test2')
+
+        # This call won't overwrite the value, since the CAS key is out of date.
+        self.assertFalse(self.client.cas('test_key', 'test3', cas))
+        self.assertEqual(self.client.get('test_key'), 'test2')
+
+    def testCasDelete(self):
+        self.assertTrue(self.client.set('test_key', 'test'))
+        value, cas = self.client.gets('test_key')
+
+        # If a different CAS value is supplied, the key is not deleted.
+        self.assertFalse(self.client.delete('test_key', cas=cas+1))
+        self.assertEqual('test', self.client.get('test_key'))
+
+        # If the correct CAS value is supplied, the key is deleted.
+        self.assertTrue(self.client.delete('test_key', cas=cas))
+        self.assertEqual(None, self.client.get('test_key'))
+
+    def testMultiCas(self):
+        # Set multiple values, some using CAS and some not.  True is returned, because
+        # both values were stored.
+        self.assertTrue(self.client.set_multi({
+            ('test_key', 0): 'value1',
+            'test_key2': 'value2',
+        }))
+
+        self.assertEqual(self.client.get('test_key'), 'value1')
+        self.assertEqual(self.client.get('test_key2'), 'value2')
+
+        # A CAS value of 0 means add.  The value already exists, so this won't overwrite it.
+        # False is returned, because not all items were stored, but test_key2 is still stored.
+        self.assertFalse(self.client.set_multi({
+            ('test_key', 0): 'value3',
+            'test_key2': 'value3',
+        }))
+
+        self.assertEqual(self.client.get('test_key'), 'value1')
+        self.assertEqual(self.client.get('test_key2'), 'value3')
+
+        # Update with the correct CAS value.
+        value, cas = self.client.gets('test_key')
+        self.assertTrue(self.client.set_multi({
+            ('test_key', cas): 'value4',
+        }))
+        self.assertEqual(self.client.get('test_key'), 'value4')
+
+    def testGetMultiCas(self):
+        self.client.set('test_key', 'value1')
+        self.client.set('test_key2', 'value2')
+
+        value1, cas1 = self.client.gets('test_key')
+        value2, cas2 = self.client.gets('test_key2')
+
+        # Batch retrieve items and their CAS values, and verify that they match
+        # the values we got by looking them up individually.
+        values = self.client.get_multi(['test_key', 'test_key2'], get_cas=True)
+        self.assertEqual(values.get('test_key')[0], 'value1')
+        self.assertEqual(values.get('test_key2')[0], 'value2')
 
     def testGetEmptyString(self):
         self.client.set('test_key', '')


### PR DESCRIPTION
This is a critical part of memcached usage.
- The API follows the pattern set by pylibmc, where CAS values are returned to the caller, and not python-memcache, which magically caches values internally.  It's simpler and much more obvious, where in python-memcache you have to enable it explicitly (since it leaks if you're not aware of it) and periodically flush the cache.
- Performing a CAS with a cas value of None is equivalent to an add.  This is logically doing a compare-and-set saying "compare against the lack of a value".  The common pattern is wanting to set a value as long as nobody else has written something since you read its value, so if you read that the item didn't exist, CAS becomes ADD.
- Multi-CAS is supported through set_multi, as well as performing some updates with CAS and some not in a single batch:

...
mc.set_multi({
    ('key', cas): value1,
    ('key2', cas2): value2,
    'key3': value,
}]
...
- The cas() API is redundant with set_multi, but was added for parity with other Python memcache clients.  I'm not sure if this is actually worth having.
- delete() supports CAS.
