### PR TITLE
Added support for re-connecting after disconnect

### DIFF
--- a/test/test_simple_functions.py
+++ b/test/test_simple_functions.py
@@ -186,3 +186,8 @@ class MemcachedTests(unittest.TestCase):
 
         stats = self.client.stats('slabs')[self.server]
         self.assertTrue('1:get_hits' in stats)
+
+    def testReconnect(self):
+        self.client.set('test_key', 'test')
+        self.client.disconnect_all()
+        self.assertEqual('test', self.client.get('test_key'))


### PR DESCRIPTION
Added support for re-connecting after disconnect. This makes the library compatible with Django's memcached cache which disconnects the client after each HTTP request.
This produces a behavior more similar to how the non binary python-memcached works after disconnect_all.
