### PR TITLE
Spelling, yo!

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 exclude *.pyc *.pyo
 recursive-include docs *
-recusrive-include tests *
+recursive-include tests *
 prune docs/_build


### PR DESCRIPTION
'recursive' was spelled 'recusrive' in MANIFEST.in. 

When installing the package, this causes a warning: `warning: manifest_maker: MANIFEST.in, line 3: unknown action 'recusrive-include'`
