### PR TITLE
Improves Unicode string handling

### DIFF
--- a/bmemcached/protocol.py
+++ b/bmemcached/protocol.py
@@ -310,7 +310,7 @@ class Protocol(threading.local):
         flags = 0
         if isinstance(value, str):
             if six.PY3:
-                value = value.encode()
+                value = value.encode('utf8')
         elif isinstance(value, int) and isinstance(value, bool) is False:
             flags |= self.FLAGS['integer']
             value = str(value)
@@ -341,7 +341,7 @@ class Protocol(threading.local):
         :return: Deserialized value
         :rtype: six.string_type|int
         """
-        to_str = lambda v: v.decode() if six.PY3 else v
+        to_str = lambda v: v.decode('utf8') if six.PY3 else v
 
         if flags & self.FLAGS['compressed']:  # pragma: no branch
             value = self.compression.decompress(value)
@@ -356,7 +356,7 @@ class Protocol(threading.local):
             unpickler = self.unpickler(buf)
             return unpickler.load()
 
-        return value.decode()
+        return to_str(value)
 
     def get(self, key):
         """
@@ -465,7 +465,7 @@ class Protocol(threading.local):
         flags, value = self.serialize(value)
         logger.info('Value bytes %d.' % len(value))
         if six.PY3 and isinstance(value, str):
-            value = value.encode()
+            value = value.encode('utf8')
 
         self._send(struct.pack(self.HEADER_STRUCT +
                                          self.COMMANDS[command]['struct'] % (len(key), len(value)),

--- a/test/test_simple_functions.py
+++ b/test/test_simple_functions.py
@@ -112,6 +112,10 @@ class MemcachedTests(unittest.TestCase):
         self.client.set('test_key', '')
         self.assertEqual('', self.client.get('test_key'))
 
+    def testGetUnicodeString(self):
+        self.client.set('test_key', '\xac')
+        self.assertEqual('\xac', self.client.get('test_key'))
+
     def testGetMulti(self):
         self.assertTrue(self.client.set_multi({
             'test_key': 'value',


### PR DESCRIPTION
Doesn't attempt to decode strings in PY2
Explicitly encodes and decodes with utf8, to match python-memcached's behavior