### PR TITLE
Use a binary string to compare the auth method

### DIFF
--- a/bmemcached/protocol.py
+++ b/bmemcached/protocol.py
@@ -269,7 +269,7 @@ class Protocol(threading.local):
 
         methods = extra_content
 
-        if 'PLAIN' not in methods:
+        if b'PLAIN' not in methods:
             raise AuthenticationNotSupported('This module only supports '
                                              'PLAIN auth for now.')
 

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -36,7 +36,7 @@ class TestServerAuth(unittest.TestCase):
         """
         Raise MemcachedException for anything unsuccessful.
         """
-        mocked_response.return_value = (0, 0, 0, 0, 0, 0x01, 0, 0, 0, ['PLAIN'])
+        mocked_response.return_value = (0, 0, 0, 0, 0, 0x01, 0, 0, 0, [b'PLAIN'])
         server = bmemcached.client.Protocol('127.0.0.1')
         self.assertRaises(MemcachedException,
                           server.authenticate, 'user', 'password')
@@ -46,7 +46,7 @@ class TestServerAuth(unittest.TestCase):
         """
         Valid logins return True.
         """
-        mocked_response.return_value = (0, 0, 0, 0, 0, 0, 0, 0, 0, ['PLAIN'])
+        mocked_response.return_value = (0, 0, 0, 0, 0, 0, 0, 0, 0, [b'PLAIN'])
         server = bmemcached.client.Protocol('127.0.0.1')
         self.assertTrue(server.authenticate('user', 'password'))
 
@@ -55,7 +55,7 @@ class TestServerAuth(unittest.TestCase):
         """
         Invalid logins raise InvalidCredentials
         """
-        mocked_response.return_value = (0, 0, 0, 0, 0, 0x08, 0, 0, 0, ['PLAIN'])
+        mocked_response.return_value = (0, 0, 0, 0, 0, 0x08, 0, 0, 0, [b'PLAIN'])
         server = bmemcached.client.Protocol('127.0.0.1')
         self.assertRaises(InvalidCredentials, server.authenticate,
                           'user', 'password2')

--- a/test/test_server_parsing.py
+++ b/test/test_server_parsing.py
@@ -43,7 +43,7 @@ class TestServerParsing(unittest.TestCase):
         """
         If username/password passed to Client, auto-authenticate.
         """
-        mocked_response.return_value = (0, 0, 0, 0, 0, 0, 0, 0, 0, ['PLAIN'])
+        mocked_response.return_value = (0, 0, 0, 0, 0, 0, 0, 0, 0, [b'PLAIN'])
         client = bmemcached.Client('127.0.0.1:11211', username='user',
                                    password='password')
         server = list(client.servers)[0]
@@ -56,7 +56,7 @@ class TestServerParsing(unittest.TestCase):
 
     @mock.patch.object(bmemcached.client.Protocol, '_get_response')
     def testNoCredentialsNoAuth(self, mocked_response):
-        mocked_response.return_value = (0, 0, 0, 0, 0, 0x01, 0, 0, 0, ['PLAIN'])
+        mocked_response.return_value = (0, 0, 0, 0, 0, 0x01, 0, 0, 0, [b'PLAIN'])
         client = bmemcached.Client('127.0.0.1:11211')
         server = list(client.servers)[0]
 


### PR DESCRIPTION
Otherwise it will fail if using Python 3.x, with the `TypeError` exception : `Type str doesn't support the buffer API`.

Cheers