### PR TITLE
Add 'raw' and 'compress' options; replace pickle with JSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,15 @@
 cover
 .tox
 *.egg-info
+.cache
+.eggs
+bin
+include
+lib
+lib64
+local
+man
+pip-selfcheck.json
+pyvenv.cfg
+share
+_build

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ pip-selfcheck.json
 pyvenv.cfg
 share
 _build
+dist

--- a/bmemcached/client.py
+++ b/bmemcached/client.py
@@ -14,9 +14,9 @@ class Client(object):
     :param servers: A list of servers with ip[:port] or unix socket.
     :type servers: list
     :param username: If your server requires SASL authentication, provide the username.
-    :type username: str
+    :type username: six.string_types
     :param password: If your server requires SASL authentication, provide the password.
-    :type password: str
+    :type password: six.string_types
     :param compression: This memcached client uses zlib compression by default,
         but you can change it to any Python module that provides
         `compress` and `decompress` functions, such as `bz2`.
@@ -95,7 +95,7 @@ class Client(object):
         Get a key from server.
 
         :param key: Key's name
-        :type key: str
+        :type key: six.string_types
         :param get_cas: If true, return (value, cas), where cas is the new CAS value.
         :type get_cas: boolean
         :param raw: If true, the binary string value will be returned without
@@ -119,7 +119,7 @@ class Client(object):
         This method is for API compatibility with other implementations.
 
         :param key: Key's name
-        :type key: str
+        :type key: six.string_types
         :return: Returns (key data, value), or (None, None) if the value is not in cache.
         :rtype: object
         """
@@ -182,7 +182,7 @@ class Client(object):
         Set a value for a key on server if its CAS value matches cas.
 
         :param key: Key's name
-        :type key: str
+        :type key: six.string_types
         :param value: A value to be stored on server.
         :type value: object
         :param time: Time in seconds that your key will expire.
@@ -223,7 +223,7 @@ class Client(object):
         Add a key/value to server ony if it does not exist.
 
         :param key: Key's name
-        :type key: str
+        :type key: six.string_types
         :param value: A value to be stored on server.
         :type value: object
         :param time: Time in seconds that your key will expire.
@@ -244,7 +244,7 @@ class Client(object):
         Replace a key/value to server ony if it does exist.
 
         :param key: Key's name
-        :type key: str
+        :type key: six.string_types
         :param value: A value to be stored on server.
         :type value: object
         :param time: Time in seconds that your key will expire.
@@ -265,7 +265,7 @@ class Client(object):
         Delete a key/value from server. If key does not exist, it returns True.
 
         :param key: Key's name to be deleted
-        :type key: str
+        :type key: six.string_types
         :return: True in case o success and False in case of failure.
         :rtype: bool
         """
@@ -287,7 +287,7 @@ class Client(object):
         Increment a key, if it exists, returns it's actual value, if it don't, return 0.
 
         :param key: Key's name
-        :type key: str
+        :type key: six.string_types
         :param value: Number to be incremented
         :type value: int
         :return: Actual value of the key on server
@@ -305,7 +305,7 @@ class Client(object):
         Minimum value of decrement return is 0.
 
         :param key: Key's name
-        :type key: str
+        :type key: six.string_types
         :param value: Number to be decremented
         :type value: int
         :return: Actual value of the key on server
@@ -337,7 +337,7 @@ class Client(object):
         Return server stats.
 
         :param key: Optional if you want status from a key.
-        :type key: str
+        :type key: six.string_types
         :return: A dict with server stats
         :rtype: dict
         """

--- a/bmemcached/client.py
+++ b/bmemcached/client.py
@@ -156,7 +156,7 @@ class Client(object):
                     break
         return d
 
-    def set(self, key, value, time=0, compress=True):
+    def set(self, key, value, time=0, compress_level=-1):
         """
         Set a value for a key on server.
 
@@ -166,18 +166,20 @@ class Client(object):
         :type value: object
         :param time: Time in seconds that your key will expire.
         :type time: int
-        :param compress: If true, the value will be compressed if possible.
-        :type compress: bool
+        :param compress_level: How much to compress.
+            0 = no compression, 1 = fastest, 9 = slowest but best,
+            -1 = default compression level.
+        :type compress_level: int
         :return: True in case of success and False in case of failure
         :rtype: bool
         """
         returns = []
         for server in self.servers:
-            returns.append(server.set(key, value, time, compress=compress))
+            returns.append(server.set(key, value, time, compress_level=compress_level))
 
         return any(returns)
 
-    def cas(self, key, value, cas, time=0, compress=True):
+    def cas(self, key, value, cas, time=0, compress_level=-1):
         """
         Set a value for a key on server if its CAS value matches cas.
 
@@ -187,18 +189,20 @@ class Client(object):
         :type value: object
         :param time: Time in seconds that your key will expire.
         :type time: int
-        :param compress: If true, the value will be compressed if possible.
-        :type compress: bool
+        :param compress_level: How much to compress.
+            0 = no compression, 1 = fastest, 9 = slowest but best,
+            -1 = default compression level.
+        :type compress_level: int
         :return: True in case of success and False in case of failure
         :rtype: bool
         """
         returns = []
         for server in self.servers:
-            returns.append(server.cas(key, value, cas, time, compress=compress))
+            returns.append(server.cas(key, value, cas, time, compress_level=compress_level))
 
         return any(returns)
 
-    def set_multi(self, mappings, time=0, compress=True):
+    def set_multi(self, mappings, time=0, compress_level=-1):
         """
         Set multiple keys with it's values on server.
 
@@ -206,19 +210,21 @@ class Client(object):
         :type mappings: dict
         :param time: Time in seconds that your key will expire.
         :type time: int
-        :param compress: If true, the value will be compressed if possible.
-        :type compress: bool
+        :param compress_level: How much to compress.
+            0 = no compression, 1 = fastest, 9 = slowest but best,
+            -1 = default compression level.
+        :type compress_level: int
         :return: True in case of success and False in case of failure
         :rtype: bool
         """
         returns = []
         if mappings:
             for server in self.servers:
-                returns.append(server.set_multi(mappings, time, compress=compress))
+                returns.append(server.set_multi(mappings, time, compress_level=compress_level))
 
         return all(returns)
 
-    def add(self, key, value, time=0, compress=True):
+    def add(self, key, value, time=0, compress_level=-1):
         """
         Add a key/value to server ony if it does not exist.
 
@@ -228,18 +234,20 @@ class Client(object):
         :type value: object
         :param time: Time in seconds that your key will expire.
         :type time: int
-        :param compress: If true, the value will be compressed if possible.
-        :type compress: bool
+        :param compress_level: How much to compress.
+            0 = no compression, 1 = fastest, 9 = slowest but best,
+            -1 = default compression level.
+        :type compress_level: int
         :return: True if key is added False if key already exists
         :rtype: bool
         """
         returns = []
         for server in self.servers:
-            returns.append(server.add(key, value, time))
+            returns.append(server.add(key, value, time, compress_level=compress_level))
 
         return any(returns)
 
-    def replace(self, key, value, time=0, compress=True):
+    def replace(self, key, value, time=0, compress_level=-1):
         """
         Replace a key/value to server ony if it does exist.
 
@@ -249,14 +257,16 @@ class Client(object):
         :type value: object
         :param time: Time in seconds that your key will expire.
         :type time: int
-        :param compress: If true, the value will be compressed if possible.
-        :type compress: bool
+        :param compress_level: How much to compress.
+            0 = no compression, 1 = fastest, 9 = slowest but best,
+            -1 = default compression level.
+        :type compress_level: int
         :return: True if key is replace False if key does not exists
         :rtype: bool
         """
         returns = []
         for server in self.servers:
-            returns.append(server.replace(key, value, time, compress=compress))
+            returns.append(server.replace(key, value, time, compress_level=compress_level))
 
         return any(returns)
 

--- a/bmemcached/client.py
+++ b/bmemcached/client.py
@@ -90,7 +90,7 @@ class Client(object):
         # add exponential falloff in the future.  _set_retry_delay is exposed for tests.
         self._set_retry_delay(5 if enable else 0)
 
-    def get(self, key, get_cas=False, raw=False):
+    def get(self, key, get_cas=False):
         """
         Get a key from server.
 
@@ -98,14 +98,11 @@ class Client(object):
         :type key: six.string_types
         :param get_cas: If true, return (value, cas), where cas is the new CAS value.
         :type get_cas: boolean
-        :param raw: If true, the binary string value will be returned without
-            decoding or conversion (but with decompression). Default is false.
-        :type raw: bool
         :return: Returns a key data from server.
         :rtype: object
         """
         for server in self.servers:
-            value, cas = server.get(key, raw=raw)
+            value, cas = server.get(key)
             if value is not None:
                 if get_cas:
                     return value, cas
@@ -129,7 +126,7 @@ class Client(object):
                 return value, cas
         return None, None
 
-    def get_multi(self, keys, get_cas=False, raw=False):
+    def get_multi(self, keys, get_cas=False):
         """
         Get multiple keys from server.
 
@@ -137,16 +134,13 @@ class Client(object):
         :type keys: list
         :param get_cas: If get_cas is true, each value is (data, cas), with each result's CAS value.
         :type get_cas: boolean
-        :param raw: If true, the binary string value will be returned without
-            decoding or conversion (but with decompression). Default is false.
-        :type raw: bool
         :return: A dict with all requested keys.
         :rtype: dict
         """
         d = {}
         if keys:
             for server in self.servers:
-                results = server.get_multi(keys, raw=raw)
+                results = server.get_multi(keys)
                 if not get_cas:
                     for key, (value, cas) in results.items():
                         results[key] = value

--- a/bmemcached/protocol.py
+++ b/bmemcached/protocol.py
@@ -246,7 +246,7 @@ class Protocol(threading.local):
         if not self._username or not self._password:
             return False
 
-        logger.info('Authenticating as %s' % self._username)
+        logger.info('Authenticating as %s', self._username)
         self._send(struct.pack(self.HEADER_STRUCT,
                                self.MAGIC['request'],
                                self.COMMANDS['auth_negotiation']['command'],
@@ -291,7 +291,7 @@ class Protocol(threading.local):
         if status != self.STATUS['success']:
             raise MemcachedException('Code: %d Message: %s' % (status, extra_content))
 
-        logger.debug('Auth OK. Code: %d Message: %s' % (status, extra_content))
+        logger.debug('Auth OK. Code: %d Message: %s', status, extra_content)
 
         self.authenticated = True
         return True
@@ -396,7 +396,7 @@ class Protocol(threading.local):
         :return: Returns (value, cas).
         :rtype: object
         """
-        logger.info('Getting key %s' % key)
+        logger.debug('Getting key %s', key)
         data = struct.pack(self.HEADER_STRUCT +
                            self.COMMANDS['get']['struct'] % (len(key)),
                            self.MAGIC['request'],
@@ -407,13 +407,12 @@ class Protocol(threading.local):
         (magic, opcode, keylen, extlen, datatype, status, bodylen, opaque,
          cas, extra_content) = self._get_response()
 
-        logger.debug('Value Length: %d. Body length: %d. Data type: %d' % (
-            extlen, bodylen, datatype))
+        logger.debug('Value Length: %d. Body length: %d. Data type: %d',
+                     extlen, bodylen, datatype)
 
         if status != self.STATUS['success']:
             if status == self.STATUS['key_not_found']:
-                logger.debug('Key not found. Message: %s'
-                             % extra_content)
+                logger.debug('Key not found. Message: %s', extra_content)
                 return None, None
 
             if status == self.STATUS['server_disconnected']:
@@ -495,9 +494,9 @@ class Protocol(threading.local):
         :rtype: bool
         """
         time = time if time >= 0 else self.MAXIMUM_EXPIRE_TIME
-        logger.info('Setting/adding/replacing key %s.' % key)
+        logger.debug('Setting/adding/replacing key %s.', key)
         flags, value = self.serialize(value, compress=compress)
-        logger.info('Value bytes %d.' % len(value))
+        logger.debug('Value bytes %s.', len(value))
         if isinstance(value, text_type):
             value = value.encode('utf8')
 
@@ -748,7 +747,7 @@ class Protocol(threading.local):
         :return: True in case o success and False in case of failure.
         :rtype: bool
         """
-        logger.info('Deleting key %s' % key)
+        logger.debug('Deleting key %s', key)
         self._send(struct.pack(self.HEADER_STRUCT +
                                self.COMMANDS['delete']['struct'] % len(key),
                                self.MAGIC['request'],
@@ -763,7 +762,7 @@ class Protocol(threading.local):
         if status != self.STATUS['success'] and status not in (self.STATUS['key_not_found'], self.STATUS['key_exists']):
             raise MemcachedException('Code: %d message: %s' % (status, extra_content))
 
-        logger.debug('Key deleted %s' % key)
+        logger.debug('Key deleted %s', key)
         return status != self.STATUS['key_exists']
 
     def delete_multi(self, keys):
@@ -775,7 +774,7 @@ class Protocol(threading.local):
         :return: True in case of success and False in case of failure.
         :rtype: bool
         """
-        logger.info('Deleting keys %r' % keys)
+        logger.debug('Deleting keys %r', keys)
         if six.PY2:
             msg = ''
         else:

--- a/bmemcached/protocol.py
+++ b/bmemcached/protocol.py
@@ -9,15 +9,10 @@ try:
 except ImportError:
     from urllib.parse import splitport
 
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
-    assert pickle
-
 import zlib
 from io import BytesIO
 import six
+from six import binary_type, text_type
 
 from bmemcached.compat import long
 from bmemcached.exceptions import AuthenticationNotSupported, InvalidCredentials, MemcachedException
@@ -277,7 +272,7 @@ class Protocol(threading.local):
 
         method = b'PLAIN'
         auth = '\x00%s\x00%s' % (self._username, self._password)
-        if six.PY3:
+        if isinstance(auth, text_type):
             auth = auth.encode()
 
         self._send(struct.pack(self.HEADER_STRUCT +
@@ -302,9 +297,9 @@ class Protocol(threading.local):
         self.authenticated = True
         return True
 
-    def serialize(self, value):
+    def serialize(self, value, compress=True):
         """
-        Serializes a value based on it's type.
+        Serializes a value based on its type.
 
         :param value: Something to be serialized
         :type value: six.string_type, int, long, object
@@ -312,9 +307,11 @@ class Protocol(threading.local):
         :rtype: str
         """
         flags = 0
-        if isinstance(value, str):
-            if six.PY3:
-                value = value.encode('utf8')
+        if isinstance(value, binary_type):
+            # The value is already encoded.
+            pass
+        elif isinstance(value, text_type):
+            value = value.encode('utf8')
         elif isinstance(value, int) and isinstance(value, bool) is False:
             flags |= self.FLAGS['integer']
             value = str(value)
@@ -328,13 +325,16 @@ class Protocol(threading.local):
             pickler.dump(value)
             value = buf.getvalue()
 
-        if len(value) > self.COMPRESSION_THRESHOLD:
-            value = self.compression.compress(value)
-            flags |= self.FLAGS['compressed']
+        if compress and len(value) > self.COMPRESSION_THRESHOLD:
+            compressed_value = self.compression.compress(value)
+            # Use the compressed value only if it is actually smaller.
+            if compressed_value and len(compressed_value) < len(value):
+                value = compressed_value
+                flags |= self.FLAGS['compressed']
 
         return flags, value
 
-    def deserialize(self, value, flags):
+    def deserialize(self, value, flags, raw=False):
         """
         Deserialized values based on flags or just return it if it is not serialized.
 
@@ -342,13 +342,22 @@ class Protocol(threading.local):
         :type value: six.string_type, int
         :param flags: Value flags
         :type flags: int
+        :param raw: If true, the binary string value will be returned without
+            decoding or conversion (but with decompression). Default is false.
+        :type raw: bool
         :return: Deserialized value
         :rtype: six.string_type|int
         """
-        to_str = lambda v: v.decode('utf8') if six.PY3 else v
-
         if flags & self.FLAGS['compressed']:  # pragma: no branch
             value = self.compression.decompress(value)
+
+        if raw:
+            return value
+
+        if six.PY3:
+            to_str = lambda v: v.decode('utf8')
+        else:
+            to_str = lambda v: v
 
         if flags & self.FLAGS['integer']:
             return int(to_str(value))
@@ -362,13 +371,16 @@ class Protocol(threading.local):
 
         return to_str(value)
 
-    def get(self, key):
+    def get(self, key, raw=False):
         """
         Get a key and its CAS value from server.  If the value isn't cached, return
         (None, None).
 
         :param key: Key's name
         :type key: six.string_type
+        :param raw: If true, the binary string value will be returned without
+            decoding or conversion (but with decompression). Default is false.
+        :type raw: bool
         :return: Returns (value, cas).
         :rtype: object
         """
@@ -399,14 +411,17 @@ class Protocol(threading.local):
 
         flags, value = struct.unpack('!L%ds' % (bodylen - 4, ), extra_content)
 
-        return self.deserialize(value, flags), cas
+        return self.deserialize(value, flags, raw=raw), cas
 
-    def get_multi(self, keys):
+    def get_multi(self, keys, raw=False):
         """
         Get multiple keys from server.
 
         :param keys: A list of keys to from server.
         :type keys: list
+        :param raw: If true, the binary string values will be returned without
+            decoding or conversion (but with decompression). Default is false.
+        :type raw: bool
         :return: A dict with all requested keys.
         :rtype: dict
         """
@@ -442,7 +457,7 @@ class Protocol(threading.local):
                 flags, key, value = struct.unpack('!L%ds%ds' %
                                                   (keylen, bodylen - keylen - 4),
                                                   extra_content)
-                d[key.decode()] = self.deserialize(value, flags), cas
+                d[key.decode()] = self.deserialize(value, flags, raw=raw), cas
             elif status == self.STATUS['server_disconnected']:
                 break
             elif status != self.STATUS['key_not_found']:
@@ -450,7 +465,7 @@ class Protocol(threading.local):
 
         return d
 
-    def _set_add_replace(self, command, key, value, time, cas=0):
+    def _set_add_replace(self, command, key, value, time, cas=0, compress=True):
         """
         Function to set/add/replace commands.
 
@@ -462,14 +477,16 @@ class Protocol(threading.local):
         :type time: int
         :param cas: The CAS value that must be matched for this operation to complete, or 0 for no CAS.
         :type cas: int
+        :param compress: If true, the value will be compressed if possible.
+        :type compress: bool
         :return: True in case of success and False in case of failure
         :rtype: bool
         """
         time = time if time >= 0 else self.MAXIMUM_EXPIRE_TIME
         logger.info('Setting/adding/replacing key %s.' % key)
-        flags, value = self.serialize(value)
+        flags, value = self.serialize(value, compress=compress)
         logger.info('Value bytes %d.' % len(value))
-        if six.PY3 and isinstance(value, str):
+        if isinstance(value, text_type):
             value = value.encode('utf8')
 
         self._send(struct.pack(self.HEADER_STRUCT +
@@ -493,7 +510,7 @@ class Protocol(threading.local):
 
         return True
 
-    def set(self, key, value, time):
+    def set(self, key, value, time, compress=True):
         """
         Set a value for a key on server.
 
@@ -503,12 +520,14 @@ class Protocol(threading.local):
         :type value: object
         :param time: Time in seconds that your key will expire.
         :type time: int
+        :param compress: If true, the value will be compressed if possible.
+        :type compress: bool
         :return: True in case of success and False in case of failure
         :rtype: bool
         """
-        return self._set_add_replace('set', key, value, time)
+        return self._set_add_replace('set', key, value, time, compress=compress)
 
-    def cas(self, key, value, cas, time):
+    def cas(self, key, value, cas, time, compress=True):
         """
         Add a key/value to server ony if it does not exist.
 
@@ -518,6 +537,8 @@ class Protocol(threading.local):
         :type value: object
         :param time: Time in seconds that your key will expire.
         :type time: int
+        :param compress: If true, the value will be compressed if possible.
+        :type compress: bool
         :return: True if key is added False if key already exists and has a different CAS
         :rtype: bool
         """
@@ -529,11 +550,11 @@ class Protocol(threading.local):
         # If we get a cas of None, interpret that as "compare against nonexistant and set",
         # which is simply Add.
         if cas is None:
-            return self._set_add_replace('add', key, value, time)
+            return self._set_add_replace('add', key, value, time, compress=compress)
         else:
-            return self._set_add_replace('set', key, value, time, cas=cas)
+            return self._set_add_replace('set', key, value, time, cas=cas, compress=compress)
 
-    def add(self, key, value, time):
+    def add(self, key, value, time, compress=True):
         """
         Add a key/value to server ony if it does not exist.
 
@@ -543,12 +564,14 @@ class Protocol(threading.local):
         :type value: object
         :param time: Time in seconds that your key will expire.
         :type time: int
+        :param compress: If true, the value will be compressed if possible.
+        :type compress: bool
         :return: True if key is added False if key already exists
         :rtype: bool
         """
-        return self._set_add_replace('add', key, value, time)
+        return self._set_add_replace('add', key, value, time, compress=compress)
 
-    def replace(self, key, value, time):
+    def replace(self, key, value, time, compress=True):
         """
         Replace a key/value to server ony if it does exist.
 
@@ -558,12 +581,14 @@ class Protocol(threading.local):
         :type value: object
         :param time: Time in seconds that your key will expire.
         :type time: int
+        :param compress: If true, the value will be compressed if possible.
+        :type compress: bool
         :return: True if key is replace False if key does not exists
         :rtype: bool
         """
-        return self._set_add_replace('replace', key, value, time)
+        return self._set_add_replace('replace', key, value, time, compress=compress)
 
-    def set_multi(self, mappings, time=100):
+    def set_multi(self, mappings, time=100, compress=True):
         """
         Set multiple keys with its values on server.
 
@@ -574,6 +599,8 @@ class Protocol(threading.local):
         :type mappings: dict
         :param time: Time in seconds that your key will expire.
         :type time: int
+        :param compress: If true, the value will be compressed if possible.
+        :type compress: bool
         :return: True
         :rtype: bool
         """
@@ -593,7 +620,7 @@ class Protocol(threading.local):
             else:
                 command = 'setq'
 
-            flags, value = self.serialize(value)
+            flags, value = self.serialize(value, compress=compress)
             m = struct.pack(self.HEADER_STRUCT +
                             self.COMMANDS[command]['struct'] % (len(key), len(value)),
                             self.MAGIC['request'],
@@ -665,7 +692,7 @@ class Protocol(threading.local):
 
     def incr(self, key, value, default=0, time=1000000):
         """
-        Increment a key, if it exists, returns it's actual value, if it don't, return 0.
+        Increment a key, if it exists, returns its actual value, if it doesn't, return 0.
 
         :param key: Key's name
         :type key: six.string_type
@@ -682,7 +709,7 @@ class Protocol(threading.local):
 
     def decr(self, key, value, default=0, time=100):
         """
-        Decrement a key, if it exists, returns it's actual value, if it don't, return 0.
+        Decrement a key, if it exists, returns its actual value, if it doesn't, return 0.
         Minimum value of decrement return is 0.
 
         :param key: Key's name
@@ -700,7 +727,7 @@ class Protocol(threading.local):
 
     def delete(self, key, cas=0):
         """
-        Delete a key/value from server. If key existed and was deleted, it returns True.
+        Delete a key/value from server. If key existed and was deleted, return True.
 
         :param key: Key's name to be deleted
         :type key: six.string_type
@@ -806,7 +833,7 @@ class Protocol(threading.local):
         """
         # TODO: Stats with key is not working.
         if key is not None:
-            if isinstance(key, str) and six.PY3:
+            if isinstance(key, text_type):
                 key = str_to_bytes(key)
             keylen = len(key)
             packed = struct.pack(

--- a/bmemcached/protocol.py
+++ b/bmemcached/protocol.py
@@ -163,7 +163,7 @@ class Protocol(threading.local):
         :param size: Size in bytes to be read.
         :type size: int
         :return: Data from socket
-        :rtype: six.string_type
+        :rtype: six.string_types
         """
         value = b''
         while len(value) < size:
@@ -227,9 +227,9 @@ class Protocol(threading.local):
         Authenticate user on server.
 
         :param username: Username used to be authenticated.
-        :type username: six.string_type
+        :type username: six.string_types
         :param password: Password used to be authenticated.
-        :type password: six.string_type
+        :type password: six.string_types
         :return: True if successful.
         :raises: InvalidCredentials, AuthenticationNotSupported, MemcachedException
         :rtype: bool
@@ -301,7 +301,7 @@ class Protocol(threading.local):
         Serializes a value based on its type.
 
         :param value: Something to be serialized
-        :type value: six.string_type, int, long, object
+        :type value: six.string_types, int, long, object
         :return: Serialized type
         :rtype: str
         """
@@ -338,14 +338,14 @@ class Protocol(threading.local):
         Deserialized values based on flags or just return it if it is not serialized.
 
         :param value: Serialized or not value.
-        :type value: six.string_type, int
+        :type value: six.string_types, int
         :param flags: Value flags
         :type flags: int
         :param raw: If true, the binary string value will be returned without
             decoding or conversion (but with decompression). Default is false.
         :type raw: bool
         :return: Deserialized value
-        :rtype: six.string_type|int
+        :rtype: six.string_types|int
         """
         FLAGS = self.FLAGS
 
@@ -389,7 +389,7 @@ class Protocol(threading.local):
         (None, None).
 
         :param key: Key's name
-        :type key: six.string_type
+        :type key: six.string_types
         :param raw: If true, the binary string value will be returned without
             decoding or conversion (but with decompression). Default is false.
         :type raw: bool
@@ -481,7 +481,7 @@ class Protocol(threading.local):
         Function to set/add/replace commands.
 
         :param key: Key's name
-        :type key: six.string_type
+        :type key: six.string_types
         :param value: A value to be stored on server.
         :type value: object
         :param time: Time in seconds that your key will expire.
@@ -526,7 +526,7 @@ class Protocol(threading.local):
         Set a value for a key on server.
 
         :param key: Key's name
-        :type key: six.string_type
+        :type key: six.string_types
         :param value: A value to be stored on server.
         :type value: object
         :param time: Time in seconds that your key will expire.
@@ -543,7 +543,7 @@ class Protocol(threading.local):
         Add a key/value to server ony if it does not exist.
 
         :param key: Key's name
-        :type key: six.string_type
+        :type key: six.string_types
         :param value: A value to be stored on server.
         :type value: object
         :param time: Time in seconds that your key will expire.
@@ -570,7 +570,7 @@ class Protocol(threading.local):
         Add a key/value to server ony if it does not exist.
 
         :param key: Key's name
-        :type key: six.string_type
+        :type key: six.string_types
         :param value: A value to be stored on server.
         :type value: object
         :param time: Time in seconds that your key will expire.
@@ -587,7 +587,7 @@ class Protocol(threading.local):
         Replace a key/value to server ony if it does exist.
 
         :param key: Key's name
-        :type key: six.string_type
+        :type key: six.string_types
         :param value: A value to be stored on server.
         :type value: object
         :param time: Time in seconds that your key will expire.
@@ -672,7 +672,7 @@ class Protocol(threading.local):
         Function which increments and decrements.
 
         :param key: Key's name
-        :type key: six.string_type
+        :type key: six.string_types
         :param value: Number to be (de|in)cremented
         :type value: int
         :param default: Default value if key does not exist.
@@ -706,7 +706,7 @@ class Protocol(threading.local):
         Increment a key, if it exists, returns its actual value, if it doesn't, return 0.
 
         :param key: Key's name
-        :type key: six.string_type
+        :type key: six.string_types
         :param value: Number to be incremented
         :type value: int
         :param default: Default value if key does not exist.
@@ -724,7 +724,7 @@ class Protocol(threading.local):
         Minimum value of decrement return is 0.
 
         :param key: Key's name
-        :type key: six.string_type
+        :type key: six.string_types
         :param value: Number to be decremented
         :type value: int
         :param default: Default value if key does not exist.
@@ -741,7 +741,7 @@ class Protocol(threading.local):
         Delete a key/value from server. If key existed and was deleted, return True.
 
         :param key: Key's name to be deleted
-        :type key: six.string_type
+        :type key: six.string_types
         :param cas: If set, only delete the key if its CAS value matches.
         :type cas: int
         :return: True in case o success and False in case of failure.
@@ -838,7 +838,7 @@ class Protocol(threading.local):
         Return server stats.
 
         :param key: Optional if you want status from a key.
-        :type key: six.string_type
+        :type key: six.string_types
         :return: A dict with server stats
         :rtype: dict
         """

--- a/bmemcached/protocol.py
+++ b/bmemcached/protocol.py
@@ -377,6 +377,12 @@ class Protocol(threading.local):
         else:
             return value
 
+    def json_dumps(self, value):
+        return json.dumps(value).encode('utf8')
+
+    def json_loads(self, value):
+        return json.loads(value.decode('utf8'))
+
     def get(self, key, raw=False):
         """
         Get a key and its CAS value from server.  If the value isn't cached, return

--- a/test/test_compression.py
+++ b/test/test_compression.py
@@ -45,7 +45,7 @@ class MemcachedTests(unittest.TestCase):
         compression.decompress.side_effect = zlib.decompress
         for proto in self.client._servers:
             proto.compression = compression
-        self.client.set('test_key', self.data, compress=True)
+        self.client.set('test_key', self.data)
         self.assertEqual(self.data, self.client.get('test_key'))
         compression.compress.assert_called_with(self.data.encode('ascii'))
         self.assertEqual(1, compression.decompress.call_count)
@@ -54,7 +54,7 @@ class MemcachedTests(unittest.TestCase):
         compression = mock.Mock()
         for proto in self.client._servers:
             proto.compression = compression
-        self.client.set('test_key', self.data, compress=False)
+        self.client.set('test_key', self.data, compress_level=0)
         self.assertEqual(self.data, self.client.get('test_key'))
         compression.compress.assert_not_called()
         compression.decompress.assert_not_called()

--- a/test/test_compression.py
+++ b/test/test_compression.py
@@ -2,6 +2,12 @@ import unittest
 import bz2
 import bmemcached
 
+import six
+if six.PY3:
+    from unittest import mock
+else:
+    import mock
+
 
 class MemcachedTests(unittest.TestCase):
     def setUp(self):
@@ -9,7 +15,7 @@ class MemcachedTests(unittest.TestCase):
         self.client = bmemcached.Client(self.server, 'user', 'password')
         self.bzclient = bmemcached.Client(self.server, 'user', 'password',
                                           compression=bz2)
-        self.data = b'this is test data. ' * 32
+        self.data = 'this is test data. ' * 32
 
     def tearDown(self):
         self.client.delete('test_key')
@@ -31,3 +37,24 @@ class MemcachedTests(unittest.TestCase):
         self.assertEqual(self.client.get('test_key'),
                 self.bzclient.get('test_key2'))
         self.assertRaises(IOError, self.bzclient.get, 'test_key')
+
+    def testCompressionEnabled(self):
+        import zlib
+        compression = mock.Mock()
+        compression.compress.side_effect = zlib.compress
+        compression.decompress.side_effect = zlib.decompress
+        for proto in self.client._servers:
+            proto.compression = compression
+        self.client.set('test_key', self.data, compress=True)
+        self.assertEqual(self.data, self.client.get('test_key'))
+        compression.compress.assert_called_with(self.data.encode('ascii'))
+        self.assertEqual(1, compression.decompress.call_count)
+
+    def testCompressionDisabled(self):
+        compression = mock.Mock()
+        for proto in self.client._servers:
+            proto.compression = compression
+        self.client.set('test_key', self.data, compress=False)
+        self.assertEqual(self.data, self.client.get('test_key'))
+        compression.compress.assert_not_called()
+        compression.decompress.assert_not_called()

--- a/test/test_error_handling.py
+++ b/test/test_error_handling.py
@@ -95,7 +95,7 @@ class MemcachedTests(unittest.TestCase):
         self._stop_proxy()
         self._start_proxy()
 
-        self.client = bmemcached.Client(self.server)
+        self.client = bmemcached.Client(self.server, 'user', 'password')
 
         # Disable retry delays, so we can disconnect and reconnect from the
         # server without needing to put delays in most of the tests.

--- a/test/test_simple_functions.py
+++ b/test/test_simple_functions.py
@@ -14,6 +14,7 @@ class MemcachedTests(unittest.TestCase):
         self.server = '127.0.0.1:11211'
         self.server = '/tmp/memcached.sock'
         self.client = bmemcached.Client(self.server, 'user', 'password')
+        self.reset()
 
     def tearDown(self):
         self.reset()

--- a/test/test_simple_functions.py
+++ b/test/test_simple_functions.py
@@ -2,12 +2,18 @@ import unittest
 import bmemcached
 from bmemcached.compat import long, unicode
 
+import six
+if six.PY3:
+    from unittest import mock
+else:
+    import mock
+
 
 class MemcachedTests(unittest.TestCase):
     def setUp(self):
         self.server = '127.0.0.1:11211'
         self.server = '/tmp/memcached.sock'
-        self.client = bmemcached.Client(self.server)
+        self.client = bmemcached.Client(self.server, 'user', 'password')
 
     def tearDown(self):
         self.reset()
@@ -29,9 +35,27 @@ class MemcachedTests(unittest.TestCase):
         self.client.set_multi(
             dict((unicode(k), b'value') for k in range(32767)))
 
-    def testGet(self):
+    def testGetSimple(self):
         self.client.set('test_key', 'test')
         self.assertEqual('test', self.client.get('test_key'))
+
+    def testGetRawBytes(self):
+        # Ensure the code is 8-bit clean.
+        value = b'\x01z\x7f\x00\x80\xfe\xff\x00'
+        self.client.set('test_key', value)
+        self.assertEqual(value, self.client.get('test_key', raw=True))
+
+    def testGetRawText(self):
+        self.client.set('test_key', u'\u30b7')
+        self.assertEqual(b'\xe3\x82\xb7', self.client.get('test_key', raw=True))
+
+    def testGetDecodedText(self):
+        self.client.set('test_key', u'\u30b7')
+        self.assertEqual(u'\u30b7', self.client.get('test_key'))
+
+    def testGetRawInt(self):
+        self.client.set('test_key', 1234)
+        self.assertEqual(b'1234', self.client.get('test_key', raw=True))
 
     def testCas(self):
         value, cas = self.client.gets('nonexistant')
@@ -221,6 +245,13 @@ class TimeoutMemcachedTests(unittest.TestCase):
     def testTimeout(self):
         self.client = bmemcached.Client(self.server, 'user', 'password',
                                         socket_timeout=0.00000000000001)
+
+        for proto in self.client._servers:
+            # Set up a mock connection that gives the impression of
+            # timing out in every recv() call.
+            proto.connection = mock.Mock()
+            proto.connection.recv.return_value = b''
+
         self.client.set('timeout_key', 'test')
         self.assertEqual(self.client.get('timeout_key'), None)
 

--- a/test/test_simple_functions.py
+++ b/test/test_simple_functions.py
@@ -40,23 +40,15 @@ class MemcachedTests(unittest.TestCase):
         self.client.set('test_key', 'test')
         self.assertEqual('test', self.client.get('test_key'))
 
-    def testGetRawBytes(self):
+    def testGetBytes(self):
         # Ensure the code is 8-bit clean.
         value = b'\x01z\x7f\x00\x80\xfe\xff\x00'
         self.client.set('test_key', value)
-        self.assertEqual(value, self.client.get('test_key', raw=True))
-
-    def testGetRawText(self):
-        self.client.set('test_key', u'\u30b7')
-        self.assertEqual(b'\xe3\x82\xb7', self.client.get('test_key', raw=True))
+        self.assertEqual(value, self.client.get('test_key'))
 
     def testGetDecodedText(self):
         self.client.set('test_key', u'\u30b7')
         self.assertEqual(u'\u30b7', self.client.get('test_key'))
-
-    def testGetRawInt(self):
-        self.client.set('test_key', 1234)
-        self.assertEqual(b'1234', self.client.get('test_key', raw=True))
 
     def testCas(self):
         value, cas = self.client.gets('nonexistant')

--- a/test/test_simple_functions.py
+++ b/test/test_simple_functions.py
@@ -138,8 +138,8 @@ class MemcachedTests(unittest.TestCase):
         self.assertEqual('', self.client.get('test_key'))
 
     def testGetUnicodeString(self):
-        self.client.set('test_key', '\xac')
-        self.assertEqual('\xac', self.client.get('test_key'))
+        self.client.set('test_key', u'\xac')
+        self.assertEqual(u'\xac', self.client.get('test_key'))
 
     def testGetMulti(self):
         self.assertTrue(self.client.set_multi({


### PR DESCRIPTION
This proposed change combines two enhancements. If you would like me to separate them, I would be happy to do so.

1) Added 'raw' and 'compress' parameters to the get and set methods.

It's currently difficult to store binary strings using this package in Python 3. (I'm caching images.) This pull request fixes that by adding an optional 'raw' bool parameter to the get() methods. The 'raw' parameter, when true, causes the client class to skip decoding and just return bytes.

I also added a 'compress' option to the set() family of methods. When 'compress' is false, it disables compression of things that don't make sense to compress, such as images (which are already compressed.)

I added tests and fixed a test that was failing on Python 3.5.2.

2) Replaced pickle with JSON as the default object serialization mechanism.

Python pickles are, sadly, dangerously insecure. The act of unpickling can execute arbitrary code. The pickle machinery is also significantly slower than most of the available Python JSON modules.

This proposed patch changes the default serialization mechanism used by this package from pickle to JSON. It is still possible to revert to pickle serialization, as proven by some unit tests I added.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jaysonsantos/python-binary-memcached/57)

<!-- Reviewable:end -->
