### PR TITLE
Issues/95 handle binary keys for python2/3

### DIFF
--- a/bmemcached/protocol.py
+++ b/bmemcached/protocol.py
@@ -478,12 +478,13 @@ class Protocol(threading.local):
                 else:
                     try:
                         decoded_key = key.decode()
+                    except UnicodeDecodeError:
+                        d[key] = self.deserialize(value, flags), cas
+                    else:
                         if decoded_key in o_keys:
                             d[decoded_key] = self.deserialize(value, flags), cas
                         else:
                             d[key] = self.deserialize(value, flags), cas
-                    except UnicodeDecodeError:
-                        d[key] = self.deserialize(value, flags), cas
 
             elif status == self.STATUS['server_disconnected']:
                 break

--- a/bmemcached/protocol.py
+++ b/bmemcached/protocol.py
@@ -376,10 +376,14 @@ class Protocol(threading.local):
 
         # In Python 2, mimic the behavior of the json library: return a str
         # unless the value contains unicode characters.
+        # in Python 2, if value is a binary (e.g struct.pack("<Q") then decode will fail
         try:
             value.decode('ascii')
         except UnicodeDecodeError:
-            return value.decode('utf8')
+            try:
+                return value.decode('utf8')
+            except UnicodeDecodeError:
+                return value
         else:
             return value
 

--- a/bmemcached/utils.py
+++ b/bmemcached/utils.py
@@ -1,11 +1,18 @@
 import six
 
-__all__ = ('str_to_bytes', )
+__all__ = ('str_to_bytes',)
 
 
 def str_to_bytes(value):
-    """Simply convert a string type to bytes."""
-    if isinstance(value, six.string_types):
+    """
+    Simply convert a string type to bytes if the value is a string
+    and is an instance of six.string_types but not of six.binary_type
+    in python2 struct.pack("<Q") is both string_types and binary_type but
+    in python3 struct.pack("<Q") is binary_type but not a string_types
+    :param value:
+    :param binary:
+    :return:
+    """
+    if not isinstance(value, six.binary_type) and isinstance(value, six.string_types):
         return value.encode()
-
     return value

--- a/test/test_simple_functions.py
+++ b/test/test_simple_functions.py
@@ -232,7 +232,8 @@ class TimeoutMemcachedTests(unittest.TestCase):
         self.client = None
 
     def tearDown(self):
-        self.client.disconnect_all()
+        if self.client:
+            self.client.disconnect_all()
         client = bmemcached.Client(self.server, 'user', 'password',
                                    socket_timeout=None)
         client.delete('timeout_key')

--- a/test/test_simple_functions.py
+++ b/test/test_simple_functions.py
@@ -1,9 +1,10 @@
 import os
 import unittest
-
 import six
-
+import struct
+import random
 import bmemcached
+import uuid
 from bmemcached.compat import long, unicode
 
 if six.PY3:
@@ -256,3 +257,275 @@ class TimeoutMemcachedTests(unittest.TestCase):
                                         socket_timeout=None)
         self.client.set('test_key_none', 'test')
         self.assertEqual(self.client.get('test_key_none'), 'test')
+
+
+class BinaryMemcachedTests(unittest.TestCase):
+    def setUp(self):
+        self.server = '{}:11211'.format(os.environ['MEMCACHED_HOST'])
+        self.server = '/tmp/memcached.sock'
+        self.client = bmemcached.Client(self.server, 'user', 'password')
+        self._inserted_keys = list()
+
+        self.reset()
+
+    def tearDown(self):
+        self.reset()
+        self.client.disconnect_all()
+
+    def bkey(self):
+        packed = struct.pack("<Q", int("%s%s%s%s" % (random.randint(1000, 9999),
+                                                     random.randint(1000, 9999),
+                                                     random.randint(1000, 9999),
+                                                     random.randint(1000, 9999))))
+        self._inserted_keys.append(packed)
+        return packed
+
+    def skey(self):
+        key = str(uuid.uuid4())[0:8]
+        self._inserted_keys.append(key)
+        return key
+
+    def reset(self):
+        for test_key in self._inserted_keys:
+            self.client.delete(test_key)
+
+    def testSet(self):
+        self.assertTrue(self.client.set(self.bkey(), 'test'))
+        self.assertTrue(self.client.set(self.skey(), 'test'))
+
+    def testSetMulti(self):
+        self.assertTrue(self.client.set_multi({
+            self.bkey(): 'value',
+            self.skey(): 'value2',
+            self.bkey(): 'value3'}))
+
+    def testSetMultiBigData(self):
+        self.client.set_multi(
+            dict((self.bkey(), b'value') for _ in range(32767)))
+        self.client.set_multi(
+            dict((self.skey(), b'value') for _ in range(32767)))
+
+    def testGetSimple(self):
+        key = self.bkey()
+        self.client.set(key, 'test')
+        self.assertEqual('test', self.client.get(key))
+        key = self.skey()
+        self.client.set(key, 'test')
+        self.assertEqual('test', self.client.get(key))
+
+    def testGetBytes(self):
+        test_key = self.bkey()
+        # Ensure the code is 8-bit clean.
+        value = b'\x01z\x7f\x00\x80\xfe\xff\x00'
+        self.client.set(test_key, value)
+        self.assertEqual(value, self.client.get(test_key))
+
+    def testGetDecodedText(self):
+        test_key = self.bkey()
+        self.client.set(test_key, u'\u30b7')
+        self.assertEqual(u'\u30b7', self.client.get(test_key))
+
+    def testCas(self):
+        value, cas = self.client.gets('nonexistant')
+        self.assertTrue(value is None)
+        self.assertTrue(cas is None)
+
+        # cas() with a cas value of None is equivalent to add.
+        test_key = self.bkey()
+        self.assertTrue(self.client.cas(test_key, 'test', cas))
+        self.assertFalse(self.client.cas(test_key, 'testX', cas))
+
+        # Load the CAS key.
+        value, cas = self.client.gets(test_key)
+        self.assertEqual('test', value)
+        self.assertTrue(cas is not None)
+
+        # Overwrite test_key only if it hasn't changed since we read it.
+        self.assertTrue(self.client.cas(test_key, 'test2', cas))
+        self.assertEqual(self.client.get(test_key), 'test2')
+
+        # This call won't overwrite the value, since the CAS key is out of date.
+        self.assertFalse(self.client.cas(test_key, 'test3', cas))
+        self.assertEqual(self.client.get(test_key), 'test2')
+
+    def testCasDelete(self):
+        test_key = self.bkey()
+        self.assertTrue(self.client.set(test_key, 'test'))
+        value, cas = self.client.gets(test_key)
+
+        # If a different CAS value is supplied, the key is not deleted.
+        self.assertFalse(self.client.delete(test_key, cas=cas + 1))
+        self.assertEqual('test', self.client.get(test_key))
+
+        # If the correct CAS value is supplied, the key is deleted.
+        self.assertTrue(self.client.delete(test_key, cas=cas))
+        self.assertEqual(None, self.client.get(test_key))
+
+    def testMultiCas(self):
+        # Set multiple values, some using CAS and some not.  True is returned, because
+        # both values were stored.
+        test_key1 = self.bkey()
+        test_key2 = self.bkey()
+        self.assertTrue(self.client.set_multi({
+            (test_key1, 0): 'value1',
+            test_key2: 'value2',
+        }))
+
+        self.assertEqual(self.client.get(test_key1), 'value1')
+        self.assertEqual(self.client.get(test_key2), 'value2')
+
+        # A CAS value of 0 means add.  The value already exists, so this won't overwrite it.
+        # False is returned, because not all items were stored, but test_key2 is still stored.
+        self.assertFalse(self.client.set_multi({
+            (test_key1, 0): 'value3',
+            test_key2: 'value3',
+        }))
+
+        self.assertEqual(self.client.get(test_key1), 'value1')
+        self.assertEqual(self.client.get(test_key2), 'value3')
+
+        # Update with the correct CAS value.
+        value, cas = self.client.gets(self.bkey())
+        self.assertTrue(self.client.set_multi({
+            (test_key1, cas): 'value4',
+        }))
+        self.assertEqual(self.client.get(test_key1), 'value4')
+
+    def testGetMultiCas(self):
+        for _ in range(0, 100):
+            test_key1 = self.bkey()
+            test_key2 = self.bkey()
+            test_key3 = self.skey()
+            self.client.set(test_key1, 'value1')
+            self.client.set(test_key2, 'value2')
+
+            value1, cas1 = self.client.gets(test_key1)
+            value2, cas2 = self.client.gets(test_key2)
+
+            # Batch retrieve items and their CAS values, and verify that they match
+            # the values we got by looking them up individually.
+            values = self.client.get_multi([test_key1, test_key2, test_key3], get_cas=True)
+            self.assertEqual(values.get(test_key1)[0], 'value1')
+            self.assertEqual(values.get(test_key2)[0], 'value2')
+
+    def testGetEmptyString(self):
+        test_key = self.bkey()
+        self.client.set(test_key, '')
+        self.assertEqual('', self.client.get(test_key))
+
+    def testGetUnicodeString(self):
+        test_key = self.bkey()
+        self.client.set(test_key, u'\xac')
+        self.assertEqual(u'\xac', self.client.get(test_key))
+
+    def testGetMulti(self):
+        test_key1 = self.bkey()
+        test_key2 = self.bkey()
+        test_key3 = self.skey()
+        test_key4 = self.skey()
+        self.assertTrue(self.client.set_multi({
+            test_key1: 'value',
+            test_key2: 'value2',
+            test_key3: 'value3',
+            test_key4: 'value4'
+
+        }))
+        self.assertEqual({test_key1: 'value', test_key2: 'value2', test_key3: 'value3'},
+                         self.client.get_multi([test_key1, test_key2, test_key3]))
+        self.assertEqual({test_key1: 'value', test_key2: 'value2', test_key3: 'value3', test_key4: 'value4'},
+                         self.client.get_multi([test_key1, test_key2, test_key3, test_key4]))
+        self.assertEqual({test_key1: 'value', test_key2: 'value2'},
+                         self.client.get_multi([test_key1, test_key2, 'nothere']))
+
+    def testGetLong(self):
+        test_key = self.bkey()
+        self.client.set(test_key, long(1))
+        value = self.client.get(test_key)
+        self.assertEqual(long(1), value)
+        self.assertTrue(isinstance(value, long))
+
+    def testGetInteger(self):
+        test_key = self.bkey()
+        self.client.set(test_key, 1)
+        value = self.client.get(test_key)
+        self.assertEqual(1, value)
+        self.assertTrue(isinstance(value, int))
+
+    def testGetBoolean(self):
+        test_key = self.bkey()
+        self.client.set(test_key, True)
+        self.assertTrue(self.client.get(test_key) is True)
+
+    def testGetObject(self):
+        test_key = self.bkey()
+        self.client.set(test_key, {'a': 1})
+        value = self.client.get(test_key)
+        self.assertTrue(isinstance(value, dict))
+        self.assertTrue('a' in value)
+        self.assertEqual(1, value['a'])
+
+    def testDelete(self):
+        test_key = self.bkey()
+        self.client.set(test_key, 'test')
+        self.assertTrue(self.client.delete(test_key))
+        self.assertEqual(None, self.client.get(test_key))
+
+    def testDeleteMulti(self):
+        test_key1 = self.bkey()
+        test_key2 = self.bkey()
+        self.client.set_multi({
+            test_key1: 'value',
+            test_key2: 'value2'})
+        self.assertTrue(self.client.delete_multi([test_key1, test_key2]))
+
+    def testDeleteUnknownKey(self):
+        test_key = self.bkey()
+        self.assertTrue(self.client.delete(test_key))
+
+    def testAddPass(self):
+        test_key = self.bkey()
+        self.assertTrue(self.client.add(test_key, 'test'))
+
+    def testAddFail(self):
+        test_key = self.bkey()
+        self.client.add(test_key, 'value')
+        self.assertFalse(self.client.add(test_key, 'test'))
+
+    def testReplacePass(self):
+        test_key = self.bkey()
+        self.client.add(test_key, 'value')
+        self.assertTrue(self.client.replace(test_key, 'value2'))
+        self.assertEqual('value2', self.client.get(test_key))
+
+    def testReplaceFail(self):
+        test_key = self.bkey()
+        self.assertFalse(self.client.replace(test_key, 'value'))
+
+    def testIncrement(self):
+        test_key = self.bkey()
+        self.assertEqual(0, self.client.incr(test_key, 1))
+        self.assertEqual(1, self.client.incr(test_key, 1))
+
+    def testDecrement(self):
+        test_key = self.bkey()
+        self.assertEqual(0, self.client.decr(test_key, 1))
+        self.assertEqual(0, self.client.decr(test_key, 1))
+
+    def testFlush(self):
+        test_key = self.bkey()
+        self.client.set(test_key, 'test')
+        self.assertTrue(self.client.flush_all())
+        self.assertEqual(None, self.client.get(test_key))
+
+    def testStats(self):
+        stats = self.client.stats()[self.server]
+        self.assertTrue('pid' in stats)
+
+        stats = self.client.stats('settings')[self.server]
+        self.assertTrue('verbosity' in stats)
+
+    def testReconnect(self):
+        test_key = self.bkey()
+        self.client.set(test_key, 'test')
+        self.client.disconnect_all()
+        self.assertEqual('test', self.client.get(test_key))

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35
+envlist = py27,py34,py35,py36
 [testenv]
 deps = -rrequirements_test.txt
 commands = python setup.py develop


### PR DESCRIPTION
* str_to_bytes:
struct.pack("<Q") returns an object which in python2 is both a six.string and six.binary but in python3 it is only a binary which is correct. hence we need to make sure the value can be encoded before using encode()

* get_multi : 
this function was using key.decode() to convert bytes back to a string before returning the result to the user . for instance without decoding the keys in the response a get_multi(['abcd', 'defg']) would return b'abcd':... , b'defg': ...

This encode/decode should only be applied to non-binary keys so if the user passes a binary key ( e.g struct.pack("<Q", 12345) then the get_multi should not try to decode this value because decoding could actually change the original value of the key

* added unit tests BinaryMemcachedTests to test read/write of binary keys via all memcached commands


* travis CI https://travis-ci.org/farshidce/python-binary-memcached

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jaysonsantos/python-binary-memcached/96)
<!-- Reviewable:end -->
