### PR TITLE
Add missing doc for the cas paramater to the cas method and add code to exceptions

### DIFF
--- a/bmemcached/client.py
+++ b/bmemcached/client.py
@@ -186,6 +186,8 @@ class Client(object):
         :type key: six.string_types
         :param value: A value to be stored on server.
         :type value: object
+        :param cas: The CAS value previously obtained from a call to get*.
+        :type cas: int
         :param time: Time in seconds that your key will expire.
         :type time: int
         :param compress_level: How much to compress.

--- a/bmemcached/exceptions.py
+++ b/bmemcached/exceptions.py
@@ -1,5 +1,6 @@
 class MemcachedException(Exception):
-    pass
+    def __init__(self, message, code):
+        self.code = code
 
 
 class AuthenticationNotSupported(MemcachedException):

--- a/bmemcached/protocol.py
+++ b/bmemcached/protocol.py
@@ -289,7 +289,7 @@ class Protocol(threading.local):
 
         if b'PLAIN' not in methods:
             raise AuthenticationNotSupported('This module only supports '
-                                             'PLAIN auth for now.')
+                                             'PLAIN auth for now.', status)
 
         method = b'PLAIN'
         auth = '\x00%s\x00%s' % (self._username, self._password)
@@ -308,10 +308,10 @@ class Protocol(threading.local):
             return False
 
         if status == self.STATUS['auth_error']:
-            raise InvalidCredentials("Incorrect username or password")
+            raise InvalidCredentials("Incorrect username or password", status)
 
         if status != self.STATUS['success']:
-            raise MemcachedException('Code: %d Message: %s' % (status, extra_content))
+            raise MemcachedException('Code: %d Message: %s' % (status, extra_content), status)
 
         logger.debug('Auth OK. Code: %d Message: %s', status, extra_content)
 
@@ -439,7 +439,7 @@ class Protocol(threading.local):
             if status == self.STATUS['server_disconnected']:
                 return None, None
 
-            raise MemcachedException('Code: %d Message: %s' % (status, extra_content))
+            raise MemcachedException('Code: %d Message: %s' % (status, extra_content), status)
 
         flags, value = struct.unpack('!L%ds' % (bodylen - 4, ), extra_content)
 
@@ -509,7 +509,7 @@ class Protocol(threading.local):
             elif status == self.STATUS['server_disconnected']:
                 break
             elif status != self.STATUS['key_not_found']:
-                raise MemcachedException('Code: %d Message: %s' % (status, extra_content))
+                raise MemcachedException('Code: %d Message: %s' % (status, extra_content), status)
 
         return d
 
@@ -556,7 +556,7 @@ class Protocol(threading.local):
                 return False
             elif status == self.STATUS['server_disconnected']:
                 return False
-            raise MemcachedException('Code: %d Message: %s' % (status, extra_content))
+            raise MemcachedException('Code: %d Message: %s' % (status, extra_content), status)
 
         return True
 
@@ -744,7 +744,7 @@ class Protocol(threading.local):
          cas, extra_content) = self._get_response()
 
         if status not in (self.STATUS['success'], self.STATUS['server_disconnected']):
-            raise MemcachedException('Code: %d Message: %s' % (status, extra_content))
+            raise MemcachedException('Code: %d Message: %s' % (status, extra_content), status)
         if status == self.STATUS['server_disconnected']:
             return 0
 
@@ -809,7 +809,7 @@ class Protocol(threading.local):
         if status == self.STATUS['server_disconnected']:
             return False
         if status != self.STATUS['success'] and status not in (self.STATUS['key_not_found'], self.STATUS['key_exists']):
-            raise MemcachedException('Code: %d message: %s' % (status, extra_content))
+            raise MemcachedException('Code: %d message: %s' % (status, extra_content), status)
 
         logger.debug('Key deleted %s', key)
         return status != self.STATUS['key_exists']
@@ -877,7 +877,7 @@ class Protocol(threading.local):
          cas, extra_content) = self._get_response()
 
         if status not in (self.STATUS['success'], self.STATUS['server_disconnected']):
-            raise MemcachedException('Code: %d message: %s' % (status, extra_content))
+            raise MemcachedException('Code: %d message: %s' % (status, extra_content), status)
 
         logger.debug('Memcached flushed')
         return True


### PR DESCRIPTION
I noticed that the cas parameter wasn't documented for the cas method.

In doing some later testing I also noticed that the error code from the server isn't exposed programmatically, so I pushed another commit which adds the error code as a "code" property to all of the exceptions.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jaysonsantos/python-binary-memcached/109)
<!-- Reviewable:end -->
