### PR TITLE
Added NOOP support

### DIFF
--- a/bmemcached/protocol.py
+++ b/bmemcached/protocol.py
@@ -444,6 +444,32 @@ class Protocol(threading.local):
         flags, value = struct.unpack('!L%ds' % (bodylen - 4, ), extra_content)
 
         return self.deserialize(value, flags), cas
+    
+    def noop(self):
+        """
+        Send a NOOP command
+        
+        :return: Returns the status.
+        :rtype: int
+        """
+        logger.debug('Sending NOOP')
+        data = struct.pack(self.HEADER_STRUCT +
+                           self.COMMANDS['noop']['struct'],
+                           self.MAGIC['request'],
+                           self.COMMANDS['noop']['command'],
+                           0, 0, 0, 0, 0, 0, 0)
+        self._send(data)
+
+        (magic, opcode, keylen, extlen, datatype, status, bodylen, opaque,
+         cas, extra_content) = self._get_response()
+
+        logger.debug('Value Length: %d. Body length: %d. Data type: %d',
+                     extlen, bodylen, datatype)
+
+        if status != self.STATUS['success']:
+            logger.debug('NOOP failed (status is %d). Message: %s' % (status, extra_content))
+        
+        return int(status)
 
     def get_multi(self, keys):
         """


### PR DESCRIPTION
We need some basic `is_alive()` function for our memcache client. We currently just call `set()` on a special key and check the result, a NOOP would be better (I think)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jaysonsantos/python-binary-memcached/122)
<!-- Reviewable:end -->
