### PR TITLE
Configure Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,19 @@
+task:
+  matrix:
+    - name: lint
+      env:
+        STEP: lint
+      container:
+        image: python:latest
+    - name: test
+      env:
+        STEP: test
+      container:
+        matrix:
+          - image: python:2.7
+          - image: python:3.4
+          - image: python:3.5
+          - image: python:3.6
+          - image: python:3.7
+  install_script: pip install -r requirements_test.txt && python setup.py develop
+  script: ./.travis-runs-tests.sh


### PR DESCRIPTION
I saw you have troubles with running Python 3.7 in CI. This change proposes to use Cirrus CI with [official Python Docker Images](https://hub.docker.com/_/python/).

I also made the linter to run only once.

![image](https://user-images.githubusercontent.com/989066/43961735-ca17b400-9c83-11e8-9e59-485f45117d6f.png)

If you'll choose to merge this change, don't forget to install [Cirrus CI App from GitHub Marketplace](https://github.com/marketplace/cirrus-ci) first.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jaysonsantos/python-binary-memcached/139)
<!-- Reviewable:end -->
