### PR TITLE
remove typing module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,5 @@ setup(
     install_requires=[
         'six',
         'uhashring',
-        'typing'
     ]
 )


### PR DESCRIPTION
Dear @jaysonsantos, thanks a lot for this module it's really useful. 
I'm not 💯 about the state of this project but found this little `bug` while trying to make it work in aws lambda.

I think by default `typing` module is shipped with python since python 3.5 so there is no real need to install it.

Thanks

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jaysonsantos/python-binary-memcached/208)
<!-- Reviewable:end -->
