### PR TITLE
remove reference to splitport()

### DIFF
--- a/bmemcached/protocol.py
+++ b/bmemcached/protocol.py
@@ -4,10 +4,6 @@ import re
 import socket
 import struct
 import threading
-try:
-    from urllib import splitport  # type: ignore
-except ImportError:
-    from urllib.parse import splitport  # type: ignore
 
 import zlib
 from io import BytesIO
@@ -177,10 +173,23 @@ class Protocol(threading.local):
         >>> split_host_port('127.0.0.1')
         ('127.0.0.1', 11211)
         """
-        host, port = splitport(server)
-        if port is None:
+        try:
+            import wingdbstub
+        except ImportError:
+            pass
+
+        parts = server.split(':')
+        if len(parts) == 2:
+            host = parts[0]
+            try:
+                port = int(parts[1])
+            except (TypeError, ValueError):
+                port = 11211
+                host = server
+        else:
+            host = parts[0]
             port = 11211
-        port = int(port)
+
         if re.search(':.*$', host):
             host = re.sub(':.*$', '', host)
         return host, port

--- a/bmemcached/protocol.py
+++ b/bmemcached/protocol.py
@@ -173,11 +173,6 @@ class Protocol(threading.local):
         >>> split_host_port('127.0.0.1')
         ('127.0.0.1', 11211)
         """
-        try:
-            import wingdbstub
-        except ImportError:
-            pass
-
         parts = server.split(':')
         if len(parts) == 2:
             host = parts[0]


### PR DESCRIPTION
with python 3.8 I'm getting warnings that `splitport()` is deprecated.  I rolled by own, rather than trying to use the official `urlparse()` method as the official version does not handle "host:port" style URLs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jaysonsantos/python-binary-memcached/229)
<!-- Reviewable:end -->
