### PR TITLE
get_multi: Support an arbitrary collection of keys, not just a list

### DIFF
--- a/bmemcached/protocol.py
+++ b/bmemcached/protocol.py
@@ -495,11 +495,7 @@ class Protocol(threading.local):
         # server
         o_keys = keys
         keys, last = keys[:-1], str_to_bytes(keys[-1])
-        if six.PY2:
-            msg = ''
-        else:
-            msg = b''
-        msg = msg.join([
+        msg = b''.join([
             struct.pack(self.HEADER_STRUCT +
                         self.COMMANDS['getkq']['struct'] % (len(key)),
                         self.MAGIC['request'],
@@ -728,10 +724,7 @@ class Protocol(threading.local):
                         0, 0, 0, 0, 0, 0, 0)
         msg.append(m)
 
-        if six.PY2:
-            msg = ''.join(msg)
-        else:
-            msg = b''.join(msg)
+        msg = b''.join(msg)
 
         self._send(msg)
 
@@ -855,10 +848,7 @@ class Protocol(threading.local):
         :rtype: bool
         """
         logger.debug('Deleting keys %r', keys)
-        if six.PY2:
-            msg = ''
-        else:
-            msg = b''
+        msg = b''
         for key in keys:
             msg += struct.pack(
                 self.HEADER_STRUCT +


### PR DESCRIPTION
This is required for compatibility with Django. Also fix a number of bugs I noticed along the way.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jaysonsantos/python-binary-memcached/230)
<!-- Reviewable:end -->
