### PR TITLE
set_multi: Return a list of keys that failed to be set

### DIFF
--- a/bmemcached/client/distributed.py
+++ b/bmemcached/client/distributed.py
@@ -71,20 +71,20 @@ class DistributedClient(ClientMixin):
             0 = no compression, 1 = fastest, 9 = slowest but best,
             -1 = default compression level.
         :type compress_level: int
-        :return: True in case of success and False in case of failure
-        :rtype: bool
+        :return: List of keys that failed to be set on any server.
+        :rtype: list
         """
-        returns = []
         if not mappings:
-            return False
+            return []
+        returns = set()
         server_mappings = defaultdict(dict)
         for key, value in mappings.items():
             server_key = self._get_server(key)
             server_mappings[server_key].update([(key, value)])
         for server, m in server_mappings.items():
-            returns.append(server.set_multi(m, time, compress_level))
+            returns |= set(server.set_multi(m, time, compress_level))
 
-        return all(returns)
+        return list(returns)
 
     def add(self, key, value, time=0, compress_level=-1):
         """

--- a/bmemcached/client/replicating.py
+++ b/bmemcached/client/replicating.py
@@ -150,15 +150,15 @@ class ReplicatingClient(ClientMixin):
             0 = no compression, 1 = fastest, 9 = slowest but best,
             -1 = default compression level.
         :type compress_level: int
-        :return: True in case of success and False in case of failure
-        :rtype: bool
+        :return: List of keys that failed to be set on any server.
+        :rtype: list
         """
-        returns = []
+        returns = set()
         if mappings:
             for server in self.servers:
-                returns.append(server.set_multi(mappings, time, compress_level=compress_level))
+                returns |= set(server.set_multi(mappings, time, compress_level=compress_level))
 
-        return all(returns)
+        return list(returns)
 
     def add(self, key, value, time=0, compress_level=-1):
         """

--- a/test/test_error_handling.py
+++ b/test/test_error_handling.py
@@ -1,6 +1,7 @@
 import multiprocessing
 import os
 import select
+import six
 import socket
 import time
 import unittest
@@ -147,15 +148,15 @@ class MemcachedTests(unittest.TestCase):
         self.assertFalse(self.client.set('test_key', 'test'))
 
     def testSetMulti(self):
-        self.assertTrue(self.client.set_multi({
+        six.assertCountEqual(self, self.client.set_multi({
             'test_key': 'value',
-            'test_key2': 'value2'}))
+            'test_key2': 'value2'}), [])
 
         self._stop_proxy()
 
-        self.assertFalse(self.client.set_multi({
+        six.assertCountEqual(self, self.client.set_multi({
             'test_key': 'value',
-            'test_key2': 'value2'}))
+            'test_key2': 'value2'}), ['test_key', 'test_key2'])
 
     def testGet(self):
         self.client.set('test_key', 'test')
@@ -210,10 +211,10 @@ class MemcachedTests(unittest.TestCase):
         self.assertEqual('test', self.client.get('test_key'))
 
     def testGetMulti(self):
-        self.assertTrue(self.client.set_multi({
+        six.assertCountEqual(self, self.client.set_multi({
             'test_key': 'value',
             'test_key2': 'value2'
-        }))
+        }), [])
         self.assertEqual({'test_key': 'value', 'test_key2': 'value2'},
                          self.client.get_multi(['test_key', 'test_key2']))
 

--- a/test/test_simple_functions.py
+++ b/test/test_simple_functions.py
@@ -32,9 +32,9 @@ class MemcachedTests(unittest.TestCase):
         self.assertTrue(self.client.set('test_key', 'test'))
 
     def testSetMulti(self):
-        self.assertTrue(self.client.set_multi({
+        six.assertCountEqual(self, self.client.set_multi({
             'test_key': 'value',
-            'test_key2': 'value2'}))
+            'test_key2': 'value2'}), [])
 
     def testSetMultiBigData(self):
         self.client.set_multi(
@@ -91,29 +91,29 @@ class MemcachedTests(unittest.TestCase):
     def testMultiCas(self):
         # Set multiple values, some using CAS and some not.  True is returned, because
         # both values were stored.
-        self.assertTrue(self.client.set_multi({
+        six.assertCountEqual(self, self.client.set_multi({
             ('test_key', 0): 'value1',
             'test_key2': 'value2',
-        }))
+        }), [])
 
         self.assertEqual(self.client.get('test_key'), 'value1')
         self.assertEqual(self.client.get('test_key2'), 'value2')
 
         # A CAS value of 0 means add.  The value already exists, so this won't overwrite it.
-        # False is returned, because not all items were stored, but test_key2 is still stored.
-        self.assertFalse(self.client.set_multi({
+        # ['test_key'] is returned, because test_key is not stored, but test_key2 is still stored.
+        six.assertCountEqual(self, self.client.set_multi({
             ('test_key', 0): 'value3',
             'test_key2': 'value3',
-        }))
+        }), [('test_key', 0)])
 
         self.assertEqual(self.client.get('test_key'), 'value1')
         self.assertEqual(self.client.get('test_key2'), 'value3')
 
         # Update with the correct CAS value.
         value, cas = self.client.gets('test_key')
-        self.assertTrue(self.client.set_multi({
+        six.assertCountEqual(self, self.client.set_multi({
             ('test_key', cas): 'value4',
-        }))
+        }), [])
         self.assertEqual(self.client.get('test_key'), 'value4')
 
     def testGetMultiCas(self):
@@ -138,10 +138,10 @@ class MemcachedTests(unittest.TestCase):
         self.assertEqual(u'\xac', self.client.get('test_key'))
 
     def testGetMulti(self):
-        self.assertTrue(self.client.set_multi({
+        six.assertCountEqual(self, self.client.set_multi({
             'test_key': 'value',
             'test_key2': 'value2'
-        }))
+        }), [])
         self.assertEqual({'test_key': 'value', 'test_key2': 'value2'},
                          self.client.get_multi(['test_key', 'test_key2']))
         self.assertEqual({'test_key': 'value', 'test_key2': 'value2'},
@@ -294,10 +294,10 @@ class BinaryMemcachedTests(unittest.TestCase):
         self.assertTrue(self.client.set(self.skey(), 'test'))
 
     def testSetMulti(self):
-        self.assertTrue(self.client.set_multi({
+        six.assertCountEqual(self, self.client.set_multi({
             self.bkey(): 'value',
             self.skey(): 'value2',
-            self.bkey(): 'value3'}))
+            self.bkey(): 'value3'}), [])
 
     def testSetMultiBigData(self):
         self.client.set_multi(
@@ -366,29 +366,29 @@ class BinaryMemcachedTests(unittest.TestCase):
         # both values were stored.
         test_key1 = self.bkey()
         test_key2 = self.bkey()
-        self.assertTrue(self.client.set_multi({
+        six.assertCountEqual(self, self.client.set_multi({
             (test_key1, 0): 'value1',
             test_key2: 'value2',
-        }))
+        }), [])
 
         self.assertEqual(self.client.get(test_key1), 'value1')
         self.assertEqual(self.client.get(test_key2), 'value2')
 
         # A CAS value of 0 means add.  The value already exists, so this won't overwrite it.
-        # False is returned, because not all items were stored, but test_key2 is still stored.
-        self.assertFalse(self.client.set_multi({
+        # [test_key1] is returned, because test_key1 is not stored, but test_key2 is still stored.
+        six.assertCountEqual(self, self.client.set_multi({
             (test_key1, 0): 'value3',
             test_key2: 'value3',
-        }))
+        }), [(test_key1, 0)])
 
         self.assertEqual(self.client.get(test_key1), 'value1')
         self.assertEqual(self.client.get(test_key2), 'value3')
 
         # Update with the correct CAS value.
         value, cas = self.client.gets(self.bkey())
-        self.assertTrue(self.client.set_multi({
+        six.assertCountEqual(self, self.client.set_multi({
             (test_key1, cas): 'value4',
-        }))
+        }), [])
         self.assertEqual(self.client.get(test_key1), 'value4')
 
     def testGetMultiCas(self):
@@ -423,13 +423,13 @@ class BinaryMemcachedTests(unittest.TestCase):
         test_key2 = self.bkey()
         test_key3 = self.skey()
         test_key4 = self.skey()
-        self.assertTrue(self.client.set_multi({
+        six.assertCountEqual(self, self.client.set_multi({
             test_key1: 'value',
             test_key2: 'value2',
             test_key3: 'value3',
             test_key4: 'value4'
 
-        }))
+        }), [])
         self.assertEqual({test_key1: 'value', test_key2: 'value2', test_key3: 'value3'},
                          self.client.get_multi([test_key1, test_key2, test_key3]))
         self.assertEqual({test_key1: 'value', test_key2: 'value2', test_key3: 'value3', test_key4: 'value4'},


### PR DESCRIPTION
This is an API change, but is required for compatibility with Django.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jaysonsantos/python-binary-memcached/231)
<!-- Reviewable:end -->
