### PR TITLE
Expose incr/decr `default` and `time` protocol arguments in client class

### DIFF
--- a/bmemcached/client/distributed.py
+++ b/bmemcached/client/distributed.py
@@ -204,7 +204,7 @@ class DistributedClient(ClientMixin):
         server = self._get_server(key)
         return server.cas(key, value, cas, time, compress_level)
 
-    def incr(self, key, value):
+    def incr(self, key, value, default=0, time=1000000):
         """
         Increment a key, if it exists, returns it's actual value, if it don't, return 0.
 
@@ -212,13 +212,17 @@ class DistributedClient(ClientMixin):
         :type key: six.string_types
         :param value: Number to be incremented
         :type value: int
+        :param default: If key not set, initialize to this value
+        :type default: int
+        :param time: Time in seconds that your key will expire.
+        :type time: int
         :return: Actual value of the key on server
         :rtype: int
         """
         server = self._get_server(key)
-        return server.incr(key, value)
+        return server.incr(key, value, default=default, time=time)
 
-    def decr(self, key, value):
+    def decr(self, key, value, default=0, time=1000000):
         """
         Decrement a key, if it exists, returns it's actual value, if it don't, return 0.
         Minimum value of decrement return is 0.
@@ -227,8 +231,12 @@ class DistributedClient(ClientMixin):
         :type key: six.string_types
         :param value: Number to be decremented
         :type value: int
+        :param default: If key not set, initialize to this value
+        :type default: int
+        :param time: Time in seconds that your key will expire.
+        :type time: int
         :return: Actual value of the key on server
         :rtype: int
         """
         server = self._get_server(key)
-        return server.decr(key, value)
+        return server.decr(key, value, default=default, time=time)

--- a/bmemcached/client/replicating.py
+++ b/bmemcached/client/replicating.py
@@ -232,7 +232,7 @@ class ReplicatingClient(ClientMixin):
 
         return all(returns)
 
-    def incr(self, key, value):
+    def incr(self, key, value, default=0, time=1000000):
         """
         Increment a key, if it exists, returns it's actual value, if it don't, return 0.
 
@@ -240,16 +240,20 @@ class ReplicatingClient(ClientMixin):
         :type key: six.string_types
         :param value: Number to be incremented
         :type value: int
+        :param default: If key not set, initialize to this value
+        :type default: int
+        :param time: Time in seconds that your key will expire.
+        :type time: int
         :return: Actual value of the key on server
         :rtype: int
         """
         returns = []
         for server in self.servers:
-            returns.append(server.incr(key, value))
+            returns.append(server.incr(key, value, default=default, time=time))
 
         return returns[0]
 
-    def decr(self, key, value):
+    def decr(self, key, value, default=0, time=1000000):
         """
         Decrement a key, if it exists, returns it's actual value, if it don't, return 0.
         Minimum value of decrement return is 0.
@@ -258,11 +262,15 @@ class ReplicatingClient(ClientMixin):
         :type key: six.string_types
         :param value: Number to be decremented
         :type value: int
+        :param default: If key not set, initialize to this value
+        :type default: int
+        :param time: Time in seconds that your key will expire.
+        :type time: int
         :return: Actual value of the key on server
         :rtype: int
         """
         returns = []
         for server in self.servers:
-            returns.append(server.decr(key, value))
+            returns.append(server.decr(key, value, default=default, time=time))
 
         return returns[0]

--- a/test/test_simple_functions.py
+++ b/test/test_simple_functions.py
@@ -208,9 +208,17 @@ class MemcachedTests(unittest.TestCase):
         self.assertEqual(0, self.client.incr('test_key', 1))
         self.assertEqual(1, self.client.incr('test_key', 1))
 
+    def testIncrementInitialize(self):
+        self.assertEqual(10, self.client.incr('test_key', 1, default=10))
+        self.assertEqual(11, self.client.incr('test_key', 1, default=10))
+
     def testDecrement(self):
         self.assertEqual(0, self.client.decr('test_key', 1))
         self.assertEqual(0, self.client.decr('test_key', 1))
+
+    def testDecrementInitialize(self):
+        self.assertEqual(10, self.client.decr('test_key', 1, default=10))
+        self.assertEqual(9, self.client.decr('test_key', 1, default=10))
 
     def testFlush(self):
         self.client.set('test_key', 'test')


### PR DESCRIPTION
The protocol implements `default` and `time` arguments, but those
are not exposed in the client class implementation.

This adds those fields.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jaysonsantos/python-binary-memcached/243)
<!-- Reviewable:end -->
