### PR TITLE
Avoid `urllib.parse.splitport` DeprecationWarning

### DIFF
--- a/.github/workflows/tests-and-lint.yml
+++ b/.github/workflows/tests-and-lint.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: LizardByte/setup-python-action@v2024.919.163656
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Dependencies

--- a/bmemcached/protocol.py
+++ b/bmemcached/protocol.py
@@ -1,13 +1,12 @@
 from datetime import datetime, timedelta
 import logging
-import re
 import socket
 import struct
 import threading
 try:
-    from urllib import splitport  # type: ignore
+    from urlparse import SplitResult  # type: ignore[import-not-found]
 except ImportError:
-    from urllib.parse import splitport  # type: ignore
+    from urllib.parse import SplitResult  # type: ignore[import-not-found]
 
 import zlib
 from io import BytesIO
@@ -180,13 +179,8 @@ class Protocol(threading.local):
         >>> split_host_port('127.0.0.1')
         ('127.0.0.1', 11211)
         """
-        host, port = splitport(server)
-        if port is None:
-            port = 11211
-        port = int(port)
-        if re.search(':.*$', host):
-            host = re.sub(':.*$', '', host)
-        return host, port
+        u = SplitResult("", server, "", "", "")
+        return u.hostname, 11211 if u.port is None else u.port
 
     def _read_socket(self, size):
         """

--- a/test/test_server_parsing.py
+++ b/test/test_server_parsing.py
@@ -27,9 +27,8 @@ class TestServerParsing(unittest.TestCase):
         self.assertEqual(server.port, 11211)
 
     def testInvalidPort(self):
-        server = bmemcached.protocol.Protocol('{}:blah'.format(os.environ['MEMCACHED_HOST']))
-        self.assertEqual(server.host, os.environ['MEMCACHED_HOST'])
-        self.assertEqual(server.port, 11211)
+        with self.assertRaises(ValueError):
+            bmemcached.protocol.Protocol('{}:blah'.format(os.environ['MEMCACHED_HOST']))
 
     def testNonStandardPort(self):
         server = bmemcached.protocol.Protocol('{}:5000'.format(os.environ['MEMCACHED_HOST']))


### PR DESCRIPTION
`DeprecationWarning: urllib.parse.splitport() is deprecated as of 3.8, use urllib.parse.urlparse() instead`