### PR TITLE
Support IPv6

### DIFF
--- a/bmemcached/protocol.py
+++ b/bmemcached/protocol.py
@@ -9,6 +9,7 @@ except ImportError:
     from urllib.parse import SplitResult  # type: ignore[import-not-found]
 
 import zlib
+from ipaddress import ip_address
 from io import BytesIO
 import six
 from six import binary_type, text_type
@@ -144,9 +145,7 @@ class Protocol(threading.local):
 
         try:
             if self.host:
-                self.connection = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-                self.connection.settimeout(self.socket_timeout)
-                self.connection.connect((self.host, self.port))
+                self.connection = socket.create_connection((self.host, self.port), self.socket_timeout)
 
                 if self.tls_context:
                     self.connection = self.tls_context.wrap_socket(
@@ -174,11 +173,38 @@ class Protocol(threading.local):
 
         Port defaults to 11211.
 
+        When using IPv6 with a specified port, the address must be enclosed in brackets.
+        If the port is not specified, brackets are optional.
+
         >>> split_host_port('127.0.0.1:11211')
         ('127.0.0.1', 11211)
         >>> split_host_port('127.0.0.1')
         ('127.0.0.1', 11211)
+        >>> split_host_port('::1')
+        ('::1', 11211)
+        >>> split_host_port('[::1]')
+        ('::1', 11211)
+        >>> split_host_port('[::1]:11211')
+        ('::1', 11211)
         """
+        default_port = 11211
+
+        def is_ip_address(address):
+            try:
+                ip_address(address)
+                return True
+            except ValueError:
+                return False
+        
+        if is_ip_address(server):
+            return server, default_port
+
+        if server.startswith('['):
+            host, _, port = server[1:].partition(']')
+            if not is_ip_address(host):
+                raise ValueError('{} is not a valid IPv6 address'.format(server))
+            return host, default_port if not port else int(port.lstrip(':'))
+
         u = SplitResult("", server, "", "", "")
         return u.hostname, 11211 if u.port is None else u.port
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -41,3 +41,16 @@ def memcached_socket():
     yield p
     p.kill()
     p.wait()
+
+
+@pytest.yield_fixture(scope="session", autouse=True)
+def memcached_ipv6():
+    p = subprocess.Popen(
+        ["memcached", "-l::1"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    time.sleep(0.1)
+    yield p
+    p.kill()
+    p.wait()

--- a/test/test_server_parsing.py
+++ b/test/test_server_parsing.py
@@ -26,9 +26,38 @@ class TestServerParsing(unittest.TestCase):
         self.assertEqual(server.host, os.environ['MEMCACHED_HOST'])
         self.assertEqual(server.port, 11211)
 
+    def testIPv6(self):
+        server = bmemcached.protocol.Protocol('[::1]')
+        self.assertEqual(server.host, '::1')
+        self.assertEqual(server.port, 11211)
+        server = bmemcached.protocol.Protocol('::1')
+        self.assertEqual(server.host, '::1')
+        self.assertEqual(server.port, 11211)
+        server = bmemcached.protocol.Protocol('[2001:db8::2]')
+        self.assertEqual(server.host, '2001:db8::2')
+        self.assertEqual(server.port, 11211)
+        server = bmemcached.protocol.Protocol('2001:db8::2')
+        self.assertEqual(server.host, '2001:db8::2')
+        self.assertEqual(server.port, 11211)
+        # Since `2001:db8::2:8080` is a valid IPv6 address, 
+        # it is ambiguous whether to split it into `2001:db8::2` and `8080`
+        # or treat it as `2001:db8::2:8080`. 
+        # Therefore, it will be treated as `2001:db8::2:8080`.
+        server = bmemcached.protocol.Protocol('2001:db8::2:8080')
+        self.assertEqual(server.host, '2001:db8::2:8080')
+        self.assertEqual(server.port, 11211)
+        server = bmemcached.protocol.Protocol('[::1]:5000')
+        self.assertEqual(server.host, '::1')
+        self.assertEqual(server.port, 5000)
+        server = bmemcached.protocol.Protocol('[2001:db8::2]:5000')
+        self.assertEqual(server.host, '2001:db8::2')
+        self.assertEqual(server.port, 5000)
+
     def testInvalidPort(self):
         with self.assertRaises(ValueError):
             bmemcached.protocol.Protocol('{}:blah'.format(os.environ['MEMCACHED_HOST']))
+        with self.assertRaises(ValueError):
+            bmemcached.protocol.Protocol('[::1]:blah')
 
     def testNonStandardPort(self):
         server = bmemcached.protocol.Protocol('{}:5000'.format(os.environ['MEMCACHED_HOST']))


### PR DESCRIPTION
### Overview

This PR replaces manual socket creation with `socket.create_connection()` to support both IPv4 and IPv6 seamlessly, and updates the `split_host_port()` to support IPv6 address.

### Motivation

IPv6 Support.

Previously, the code forced `AF_INET` for socket connections, making IPv6 usage either impossible or unreliable.

For example, empty response from `client.stats()`.

```bash
python -c "import bmemcached; client = bmemcached.Client('2001:db8::2:11211', '', ''); print(client.stats())"
{'2001:db8::2:11211': {}}
```

By switching to `socket.create_connection((self.host, self.port), self.socket_timeout)`, Python automatically selects the appropriate address family (IPv4 or IPv6).

### Testing

Using `docker-compose`.
- https://docs.docker.com/engine/daemon/ipv6/
- https://docs.docker.com/compose/

```yaml
services:
  memcached:
    container_name: memcached
    image: bitnami/memcached:latest
    environment:
    - MEMCACHED_LISTEN_ADDRESS=[::]
    ports:
      - "11211:11211"
    networks:
      - ip6net
networks:
  ip6net:
    enable_ipv6: true
    ipam:
      config:
        - subnet: 2001:db8::/64
```

```bash
docker inspect memcached | grep GlobalIPv6Address
            "GlobalIPv6Address": "",
                    "GlobalIPv6Address": "2001:db8::2",
```

Make a memcached client container image.

```bash
docker build --no-cache -t memcached-client --quiet -<<-EOD
FROM python:3.9
WORKDIR /src
RUN <<RUNEND
git clone --branch support-ipv6 --depth=1 https://github.com/keisku/python-binary-memcached.git
cd python-binary-memcached
pip install .
RUNEND
EOD
```


```bash
docker run --rm --network host memcached-client python -c "import bmemcached; client = bmemcached.Client('[2001:db8::2]', '', ''); print(client.stats()); client.disconnect_all()"
{'[2001:db8::2]': {'pid': b'1', 'uptime': b'61798', 'time': b'1736215951', 'version': b'1.6.34', 'libevent': b'2.1.12-stable', 'pointer_size': b'64', 'rusage_user': b'4.650069', 'rusage_system': b'1.189757', 'max_connections': b'1024', 'curr_connections': b'1', 'total_connections': b'7', 'rejected_connections': b'0', 'connection_structures': b'2', 'response_obj_oom': b'0', 'response_obj_count': b'1', 'response_obj_bytes': b'65536', 'read_buf_count': b'8', 'read_buf_bytes': b'131072', 'read_buf_bytes_free': b'49152', 'read_buf_oom': b'0', 'reserved_fds': b'20', 'cmd_get': b'0', 'cmd_set': b'0', 'cmd_flush': b'0', 'cmd_touch': b'0', 'cmd_meta': b'0', 'get_hits': b'0', 'get_misses': b'0', 'get_expired': b'0', 'get_flushed': b'0', 'delete_misses': b'0', 'delete_hits': b'0', 'incr_misses': b'0', 'incr_hits': b'0', 'decr_misses': b'0', 'decr_hits': b'0', 'cas_misses': b'0', 'cas_hits': b'0', 'cas_badval': b'0', 'touch_hits': b'0', 'touch_misses': b'0', 'store_too_large': b'0', 'store_no_memory': b'0', 'auth_cmds': b'0', 'auth_errors': b'0', 'bytes_read': b'144', 'bytes_written': b'18501', 'limit_maxbytes': b'67108864', 'accepting_conns': b'1', 'listen_disabled_num': b'0', 'time_in_listen_disabled_us': b'0', 'threads': b'4', 'conn_yields': b'0', 'hash_power_level': b'16', 'hash_bytes': b'524288', 'hash_is_expanding': b'0', 'slab_reassign_rescues': b'0', 'slab_reassign_chunk_rescues': b'0', 'slab_reassign_inline_reclaim': b'0', 'slab_reassign_busy_items': b'0', 'slab_reassign_busy_deletes': b'0', 'slab_reassign_busy_nomem': b'0', 'slab_reassign_running': b'0', 'slabs_moved': b'0', 'lru_crawler_running': b'0', 'lru_crawler_starts': b'45', 'lru_maintainer_juggles': b'61841', 'malloc_fails': b'0', 'log_worker_dropped': b'0', 'log_worker_written': b'0', 'log_watcher_skipped': b'0', 'log_watcher_sent': b'0', 'log_watchers': b'0', 'unexpected_napi_ids': b'0', 'round_robin_fallback': b'0', 'bytes': b'0', 'curr_items': b'0', 'total_items': b'0', 'slab_global_page_pool': b'0', 'expired_unfetched': b'0', 'evicted_unfetched': b'0', 'evicted_active': b'0', 'evictions': b'0', 'reclaimed': b'0', 'crawler_reclaimed': b'0', 'crawler_items_checked': b'0', 'lrutail_reflocked': b'0', 'moves_to_cold': b'0', 'moves_to_warm': b'0', 'moves_within_lru': b'0', 'direct_reclaims': b'0', 'lru_bumps_dropped': b'0'}}

docker run --rm --network host memcached-client python -c "import bmemcached; client = bmemcached.Client('[2001:db8::2]:11211', '', ''); print(client.stats()); client.disconnect_all()"
{'[2001:db8::2]:11211': {'pid': b'1', 'uptime': b'61811', 'time': b'1736215964', 'version': b'1.6.34', 'libevent': b'2.1.12-stable', 'pointer_size': b'64', 'rusage_user': b'4.651855', 'rusage_system': b'1.189757', 'max_connections': b'1024', 'curr_connections': b'1', 'total_connections': b'9', 'rejected_connections': b'0', 'connection_structures': b'2', 'response_obj_oom': b'0', 'response_obj_count': b'1', 'response_obj_bytes': b'65536', 'read_buf_count': b'8', 'read_buf_bytes': b'131072', 'read_buf_bytes_free': b'49152', 'read_buf_oom': b'0', 'reserved_fds': b'20', 'cmd_get': b'0', 'cmd_set': b'0', 'cmd_flush': b'0', 'cmd_touch': b'0', 'cmd_meta': b'0', 'get_hits': b'0', 'get_misses': b'0', 'get_expired': b'0', 'get_flushed': b'0', 'delete_misses': b'0', 'delete_hits': b'0', 'incr_misses': b'0', 'incr_hits': b'0', 'decr_misses': b'0', 'decr_hits': b'0', 'cas_misses': b'0', 'cas_hits': b'0', 'cas_badval': b'0', 'touch_hits': b'0', 'touch_misses': b'0', 'store_too_large': b'0', 'store_no_memory': b'0', 'auth_cmds': b'0', 'auth_errors': b'0', 'bytes_read': b'192', 'bytes_written': b'25911', 'limit_maxbytes': b'67108864', 'accepting_conns': b'1', 'listen_disabled_num': b'0', 'time_in_listen_disabled_us': b'0', 'threads': b'4', 'conn_yields': b'0', 'hash_power_level': b'16', 'hash_bytes': b'524288', 'hash_is_expanding': b'0', 'slab_reassign_rescues': b'0', 'slab_reassign_chunk_rescues': b'0', 'slab_reassign_inline_reclaim': b'0', 'slab_reassign_busy_items': b'0', 'slab_reassign_busy_deletes': b'0', 'slab_reassign_busy_nomem': b'0', 'slab_reassign_running': b'0', 'slabs_moved': b'0', 'lru_crawler_running': b'0', 'lru_crawler_starts': b'45', 'lru_maintainer_juggles': b'61855', 'malloc_fails': b'0', 'log_worker_dropped': b'0', 'log_worker_written': b'0', 'log_watcher_skipped': b'0', 'log_watcher_sent': b'0', 'log_watchers': b'0', 'unexpected_napi_ids': b'0', 'round_robin_fallback': b'0', 'bytes': b'0', 'curr_items': b'0', 'total_items': b'0', 'slab_global_page_pool': b'0', 'expired_unfetched': b'0', 'evicted_unfetched': b'0', 'evicted_active': b'0', 'evictions': b'0', 'reclaimed': b'0', 'crawler_reclaimed': b'0', 'crawler_items_checked': b'0', 'lrutail_reflocked': b'0', 'moves_to_cold': b'0', 'moves_to_warm': b'0', 'moves_within_lru': b'0', 'direct_reclaims': b'0', 'lru_bumps_dropped': b'0'}}

# Without brackets.
docker run --rm --network host memcached-client python -c "import bmemcached; client = bmemcached.Client('2001:db8::2', '', ''); print(client.stats()); client.disconnect_all()"
{'2001:db8::2': {'pid': b'1', 'uptime': b'61801', 'time': b'1736215954', 'version': b'1.6.34', 'libevent': b'2.1.12-stable', 'pointer_size': b'64', 'rusage_user': b'4.650573', 'rusage_system': b'1.189757', 'max_connections': b'1024', 'curr_connections': b'1', 'total_connections': b'8', 'rejected_connections': b'0', 'connection_structures': b'2', 'response_obj_oom': b'0', 'response_obj_count': b'1', 'response_obj_bytes': b'65536', 'read_buf_count': b'8', 'read_buf_bytes': b'131072', 'read_buf_bytes_free': b'49152', 'read_buf_oom': b'0', 'reserved_fds': b'20', 'cmd_get': b'0', 'cmd_set': b'0', 'cmd_flush': b'0', 'cmd_touch': b'0', 'cmd_meta': b'0', 'get_hits': b'0', 'get_misses': b'0', 'get_expired': b'0', 'get_flushed': b'0', 'delete_misses': b'0', 'delete_hits': b'0', 'incr_misses': b'0', 'incr_hits': b'0', 'decr_misses': b'0', 'decr_hits': b'0', 'cas_misses': b'0', 'cas_hits': b'0', 'cas_badval': b'0', 'touch_hits': b'0', 'touch_misses': b'0', 'store_too_large': b'0', 'store_no_memory': b'0', 'auth_cmds': b'0', 'auth_errors': b'0', 'bytes_read': b'168', 'bytes_written': b'22206', 'limit_maxbytes': b'67108864', 'accepting_conns': b'1', 'listen_disabled_num': b'0', 'time_in_listen_disabled_us': b'0', 'threads': b'4', 'conn_yields': b'0', 'hash_power_level': b'16', 'hash_bytes': b'524288', 'hash_is_expanding': b'0', 'slab_reassign_rescues': b'0', 'slab_reassign_chunk_rescues': b'0', 'slab_reassign_inline_reclaim': b'0', 'slab_reassign_busy_items': b'0', 'slab_reassign_busy_deletes': b'0', 'slab_reassign_busy_nomem': b'0', 'slab_reassign_running': b'0', 'slabs_moved': b'0', 'lru_crawler_running': b'0', 'lru_crawler_starts': b'45', 'lru_maintainer_juggles': b'61844', 'malloc_fails': b'0', 'log_worker_dropped': b'0', 'log_worker_written': b'0', 'log_watcher_skipped': b'0', 'log_watcher_sent': b'0', 'log_watchers': b'0', 'unexpected_napi_ids': b'0', 'round_robin_fallback': b'0', 'bytes': b'0', 'curr_items': b'0', 'total_items': b'0', 'slab_global_page_pool': b'0', 'expired_unfetched': b'0', 'evicted_unfetched': b'0', 'evicted_active': b'0', 'evictions': b'0', 'reclaimed': b'0', 'crawler_reclaimed': b'0', 'crawler_items_checked': b'0', 'lrutail_reflocked': b'0', 'moves_to_cold': b'0', 'moves_to_warm': b'0', 'moves_within_lru': b'0', 'direct_reclaims': b'0', 'lru_bumps_dropped': b'0'}}
```

### Regression tests

```yaml
services:
  memcached:
    container_name: memcached
    image: bitnami/memcached:latest
```

```bash
docker inspect memcached | grep IPAddress
            "SecondaryIPAddresses": null,
            "IPAddress": "",
                    "IPAddress": "172.20.0.2",
```

```bash
docker run --rm --network host memcached-client python -c "import bmemcached; client = bmemcached.Client('172.20.0.2:11211', '', ''); print(client.stats()); client.disconnect_all()"
{'172.20.0.2:11211': {'pid': b'1', 'uptime': b'29', 'time': b'1736216159', 'version': b'1.6.34', 'libevent': b'2.1.12-stable', 'pointer_size': b'64', 'rusage_user': b'0.036675', 'rusage_system': b'0.017052', 'max_connections': b'1024', 'curr_connections': b'2', 'total_connections': b'3', 'rejected_connections': b'0', 'connection_structures': b'3', 'response_obj_oom': b'0', 'response_obj_count': b'1', 'response_obj_bytes': b'16384', 'read_buf_count': b'2', 'read_buf_bytes': b'32768', 'read_buf_bytes_free': b'0', 'read_buf_oom': b'0', 'reserved_fds': b'20', 'cmd_get': b'0', 'cmd_set': b'0', 'cmd_flush': b'0', 'cmd_touch': b'0', 'cmd_meta': b'0', 'get_hits': b'0', 'get_misses': b'0', 'get_expired': b'0', 'get_flushed': b'0', 'delete_misses': b'0', 'delete_hits': b'0', 'incr_misses': b'0', 'incr_hits': b'0', 'decr_misses': b'0', 'decr_hits': b'0', 'cas_misses': b'0', 'cas_hits': b'0', 'cas_badval': b'0', 'touch_hits': b'0', 'touch_misses': b'0', 'store_too_large': b'0', 'store_no_memory': b'0', 'auth_cmds': b'0', 'auth_errors': b'0', 'bytes_read': b'24', 'bytes_written': b'0', 'limit_maxbytes': b'67108864', 'accepting_conns': b'1', 'listen_disabled_num': b'0', 'time_in_listen_disabled_us': b'0', 'threads': b'4', 'conn_yields': b'0', 'hash_power_level': b'16', 'hash_bytes': b'524288', 'hash_is_expanding': b'0', 'slab_reassign_rescues': b'0', 'slab_reassign_chunk_rescues': b'0', 'slab_reassign_inline_reclaim': b'0', 'slab_reassign_busy_items': b'0', 'slab_reassign_busy_deletes': b'0', 'slab_reassign_busy_nomem': b'0', 'slab_reassign_running': b'0', 'slabs_moved': b'0', 'lru_crawler_running': b'0', 'lru_crawler_starts': b'1', 'lru_maintainer_juggles': b'79', 'malloc_fails': b'0', 'log_worker_dropped': b'0', 'log_worker_written': b'0', 'log_watcher_skipped': b'0', 'log_watcher_sent': b'0', 'log_watchers': b'0', 'unexpected_napi_ids': b'0', 'round_robin_fallback': b'0', 'bytes': b'0', 'curr_items': b'0', 'total_items': b'0', 'slab_global_page_pool': b'0', 'expired_unfetched': b'0', 'evicted_unfetched': b'0', 'evicted_active': b'0', 'evictions': b'0', 'reclaimed': b'0', 'crawler_reclaimed': b'0', 'crawler_items_checked': b'0', 'lrutail_reflocked': b'0', 'moves_to_cold': b'0', 'moves_to_warm': b'0', 'moves_within_lru': b'0', 'direct_reclaims': b'0', 'lru_bumps_dropped': b'0'}}

docker run --rm --network host memcached-client python -c "import bmemcached; client = bmemcached.Client('172.20.0.2', '', ''); print(client.stats()); client.disconnect_all()"
{'172.20.0.2': {'pid': b'1', 'uptime': b'35', 'time': b'1736216165', 'version': b'1.6.34', 'libevent': b'2.1.12-stable', 'pointer_size': b'64', 'rusage_user': b'0.037426', 'rusage_system': b'0.017109', 'max_connections': b'1024', 'curr_connections': b'2', 'total_connections': b'4', 'rejected_connections': b'0', 'connection_structures': b'3', 'response_obj_oom': b'0', 'response_obj_count': b'1', 'response_obj_bytes': b'32768', 'read_buf_count': b'4', 'read_buf_bytes': b'65536', 'read_buf_bytes_free': b'16384', 'read_buf_oom': b'0', 'reserved_fds': b'20', 'cmd_get': b'0', 'cmd_set': b'0', 'cmd_flush': b'0', 'cmd_touch': b'0', 'cmd_meta': b'0', 'get_hits': b'0', 'get_misses': b'0', 'get_expired': b'0', 'get_flushed': b'0', 'delete_misses': b'0', 'delete_hits': b'0', 'incr_misses': b'0', 'incr_hits': b'0', 'decr_misses': b'0', 'decr_hits': b'0', 'cas_misses': b'0', 'cas_hits': b'0', 'cas_badval': b'0', 'touch_hits': b'0', 'touch_misses': b'0', 'store_too_large': b'0', 'store_no_memory': b'0', 'auth_cmds': b'0', 'auth_errors': b'0', 'bytes_read': b'48', 'bytes_written': b'3688', 'limit_maxbytes': b'67108864', 'accepting_conns': b'1', 'listen_disabled_num': b'0', 'time_in_listen_disabled_us': b'0', 'threads': b'4', 'conn_yields': b'0', 'hash_power_level': b'16', 'hash_bytes': b'524288', 'hash_is_expanding': b'0', 'slab_reassign_rescues': b'0', 'slab_reassign_chunk_rescues': b'0', 'slab_reassign_inline_reclaim': b'0', 'slab_reassign_busy_items': b'0', 'slab_reassign_busy_deletes': b'0', 'slab_reassign_busy_nomem': b'0', 'slab_reassign_running': b'0', 'slabs_moved': b'0', 'lru_crawler_running': b'0', 'lru_crawler_starts': b'1', 'lru_maintainer_juggles': b'84', 'malloc_fails': b'0', 'log_worker_dropped': b'0', 'log_worker_written': b'0', 'log_watcher_skipped': b'0', 'log_watcher_sent': b'0', 'log_watchers': b'0', 'unexpected_napi_ids': b'0', 'round_robin_fallback': b'0', 'bytes': b'0', 'curr_items': b'0', 'total_items': b'0', 'slab_global_page_pool': b'0', 'expired_unfetched': b'0', 'evicted_unfetched': b'0', 'evicted_active': b'0', 'evictions': b'0', 'reclaimed': b'0', 'crawler_reclaimed': b'0', 'crawler_items_checked': b'0', 'lrutail_reflocked': b'0', 'moves_to_cold': b'0', 'moves_to_warm': b'0', 'moves_within_lru': b'0', 'direct_reclaims': b'0', 'lru_bumps_dropped': b'0'}}
```