### PR TITLE
Fix tox configuration and add pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,6 @@
 envlist = py38,py39,py310,py311,py312
 [testenv]
 deps = -rrequirements_test.txt
-commands = pip install -e .
-    py.test -s
+commands =
+    pytest
     flake8


### PR DESCRIPTION
- Add pyproject.toml with setuptools build system configuration
- Replace deprecated py.test invocation with pytest
- Remove redundant 'pip install -e .' from tox commands, as tox handles package installation itself

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build system configuration to use setuptools.
  * Updated test environment to run tests via pytest.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jaysonsantos/python-binary-memcached/pull/264)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->