### PR TITLE
ci: gate publish.yml on tags and move PyPI to Trusted Publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,39 +1,45 @@
-name: Publish Python 🐍 distributions 📦 to PyPI
-on: push
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
 jobs:
-  build-n-publish:
-    name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+  build-and-publish:
+    name: Build and publish to PyPI
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: pypi
+    permissions:
+      id-token: write
     steps:
-      - uses: actions/checkout@master
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v3
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
         with:
-          python-version: "3.10"
-      - name: Setup pandoc for changelog conversion
-        run: sudo apt update && sudo apt install -y pandoc
-      - name: Write pypi's readme
+          python-version: "3.12"
+
+      - name: Install pandoc
+        run: sudo apt-get update && sudo apt-get install -y pandoc
+
+      - name: Build PyPI long description from README and CHANGELOG
         run: |
           cat README.rst > to-pypi.rst
           echo "" >> to-pypi.rst
           pandoc -s --to rst -o /dev/stdout CHANGELOG.md | tee -a to-pypi.rst
           mv to-pypi.rst README.rst
-      - name: Install pypa/build
-        run: >-
-          python -m
-          pip install
-          build
-          --user
-      - name: Build a binary wheel and a source tarball
-        run: >-
-          python -m
-          build
-          --sdist
-          --wheel
-          --outdir dist/
-          .
-      - name: Publish distribution 📦 to PyPI
-        if: startsWith(github.ref, 'refs/tags')
+
+      - name: Install build
+        run: python -m pip install build
+
+      - name: Build sdist and wheel
+        run: python -m build --sdist --wheel --outdir dist/ .
+
+      - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
> # Release hazard: do the manual steps before you merge
>
> This pull request removes the `PYPI_API_TOKEN` password input. It replaces it
> with Trusted Publishing. If this merges before you register the trusted
> publisher on pypi.org, the next tag push fails to publish.
>
> Do these steps in order.
>
> 1. On pypi.org, open the project. Go to Publishing. Add a trusted publisher.
>    Set Owner `jaysonsantos`, Repository `python-binary-memcached`, Workflow
>    `publish.yml`, Environment `pypi`.
> 2. In GitHub repository settings, open Environments. Create an environment
>    named `pypi`.
> 3. Merge this pull request.
> 4. Push a tag. Confirm the publish succeeds.
> 5. Delete the `PYPI_API_TOKEN` repository secret.
>
> Steps 1, 2, and 5 are yours. I did not touch PyPI settings, GitHub
> environment settings, or the `PYPI_API_TOKEN` secret.

## What changed

`.github/workflows/publish.yml` is rewritten.

- The trigger is `push: tags: ["v*"]` plus `workflow_dispatch`. It no longer
  runs on every push. The tag pattern matches the commitizen `tag_format` of
  `v$version` in `.cz.yaml`.
- `actions/checkout@v7` and `actions/setup-python@v7`.
- The top level sets `permissions: contents: read`. The job sets
  `permissions: id-token: write` and `environment: pypi`.
- The job sets `timeout-minutes: 10`.
- The `password:` input to `pypa/gh-action-pypi-publish` is gone.

## Why

Two risks sat in one job. The checkout step read `actions/checkout@master`,
which pins a mutable branch rather than a tag or a commit SHA. Any commit that
lands on the upstream default branch ran there at once, with no review gate,
in the same job that held `secrets.PYPI_API_TOKEN`. Separately, the workflow
ran on every push to every branch, and threw the build output away each time,
because only the last step checked the ref.

## Verification

The publish job cannot run on a pull request. It triggers on a tag push and on
`workflow_dispatch` only. Verification here is limited to what runs off the
tag.

```
nix develop --command bash -c 'python -c "import yaml; yaml.safe_load(open(\".github/workflows/publish.yml\"))"'
```

Result: the workflow YAML parses.

```
nix develop --command bash -c 'pytest -q'
```

Result: `261 passed`. This matches the baseline on `main`.

```
nix develop --command bash -c 'flake8'
```

Result: 0 errors.

Action tags were checked against their upstream release lists.
`actions/checkout` is at `v7.0.1` and `actions/setup-python` at `v7.0.0`.

The real end-to-end check is step 4 above: push a tag and confirm the publish
succeeds.

## Risks

A reviewer must check four points.

1. **The manual steps at the top must happen first.** This is the whole
   hazard. A merge before step 1 and step 2 breaks the next release.
2. **`environment: pypi` must exist in GitHub settings.** A job that names a
   missing environment fails to start.
3. **`pypa/gh-action-pypi-publish` stays at `release/v1`.** That is deliberate.
   PyPA documents `release/v1` as an intended rolling branch for this action.
   This is the one floating pin that stays, and it no longer sits next to a
   long-lived token.
4. **The pandoc step is unchanged and must stay.** It appends the changelog to
   the PyPI long description. `README.rst` is a symlink to the Sphinx source
   `docs/intro.rst`. The two files use different formats, so they do not
   concatenate under one content type. Converting `README.rst` to Markdown
   would break the Sphinx build. The step rewrites `README.rst` inside the CI
   checkout only. It never commits the change back.

Out of scope, and noted in the issue: tags `v0.31.3`, `v0.31.4`, and `v0.32.0`
have no GitHub release. The newest release is `v0.31.2`. That needs its own
issue.

Closes #272


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Package publishing now runs only for version tags or when manually initiated.
  - Publishing uses a dedicated PyPI environment with trusted authentication.
  - The release workflow now uses Python 3.12 and includes improved execution safeguards.
  - Build and publishing actions have been updated to newer versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->