### PR TITLE
test: harden the conftest fixtures and close the IPv6 and SASL gaps

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -13,10 +13,11 @@
 
         python = pkgs.python312;
 
-        # The default package has no TLS, so test/test_tls.py skips.
+        # The default package has no TLS and no SASL, so test/test_tls.py and the
+        # SASL integration test both skip.
         memcached = pkgs.memcached.overrideAttrs (old: {
-          buildInputs = (old.buildInputs or [ ]) ++ [ pkgs.openssl ];
-          configureFlags = (old.configureFlags or [ ]) ++ [ "--enable-tls" ];
+          buildInputs = (old.buildInputs or [ ]) ++ [ pkgs.openssl pkgs.cyrus_sasl ];
+          configureFlags = (old.configureFlags or [ ]) ++ [ "--enable-tls" "--enable-sasl" "--enable-sasl-pwdb" ];
         });
 
         # Runtime and test dependencies from setup.py and requirements_test.txt.
@@ -46,6 +47,7 @@
           packages = [
             pythonEnv
             memcached
+            pkgs.cyrus_sasl.bin
             pkgs.pre-commit
             pkgs.commitizen
           ];

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,5 +1,8 @@
 import os
+import shutil
+import socket
 import subprocess
+import tempfile
 import time
 
 import pytest
@@ -7,50 +10,212 @@ import pytest
 
 os.environ.setdefault("MEMCACHED_HOST", "localhost")
 
+# How long to wait for a memcached process to accept a connection.
+START_TIMEOUT = 10.0
+POLL_INTERVAL = 0.02
 
-@pytest.yield_fixture(scope="session", autouse=True)
+SOCKET_PATH = "/tmp/memcached.sock"
+IPV6_PORT = 5002
+SASL_PORT = 5003
+
+
+def _fail_reason(process, description):
+    """
+    Return a skip message when the process is not usable, else None.
+    """
+    if process.poll() is None:
+        return None
+
+    stderr = b""
+    try:
+        stderr = process.communicate(timeout=1)[1] or b""
+    except subprocess.TimeoutExpired:  # pragma: no cover - defensive
+        pass
+
+    return "{} exited with code {}. {}".format(
+        description, process.returncode, stderr.decode("utf8", "replace").strip()
+    )
+
+
+def _wait_until_accepting(process, description, connect):
+    """
+    Wait until ``connect`` succeeds, or skip with a clear reason.
+
+    A fixed sleep is not enough. A slow start makes it flaky, and a memcached
+    that never started at all gives an opaque ConnectionRefusedError in every
+    test instead of one clear skip.
+    """
+    deadline = time.time() + START_TIMEOUT
+    last_error = None
+
+    while time.time() < deadline:
+        reason = _fail_reason(process, description)
+        if reason is not None:
+            pytest.skip(reason)
+
+        try:
+            connect().close()
+            return process
+        except OSError as error:
+            last_error = error
+            time.sleep(POLL_INTERVAL)
+
+    process.kill()
+    process.wait()
+    pytest.skip(
+        "{} did not accept a connection within {:.0f}s. Last error: {}".format(
+            description, START_TIMEOUT, last_error
+        )
+    )
+
+
+def _start(args, description, connect):
+    """
+    Start a memcached process and wait for it to accept a connection.
+    """
+    try:
+        process = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    except OSError as error:
+        pytest.skip("Cannot run {}: {}. Is memcached on PATH?".format(args[0], error))
+
+    return _wait_until_accepting(process, description, connect)
+
+
+def _stop(process):
+    process.kill()
+    process.wait()
+
+
+def _tcp(host, port, family=socket.AF_INET):
+    def connect():
+        sock = socket.socket(family, socket.SOCK_STREAM)
+        sock.settimeout(POLL_INTERVAL * 10)
+        sock.connect((host, port))
+        return sock
+
+    return connect
+
+
+def _unix(path):
+    def connect():
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.settimeout(POLL_INTERVAL * 10)
+        sock.connect(path)
+        return sock
+
+    return connect
+
+
+@pytest.fixture(scope="session", autouse=True)
 def memcached_standard_port():
-    p = subprocess.Popen(
-        ["memcached"], stdout=subprocess.PIPE, stderr=subprocess.PIPE
-    )
-    time.sleep(0.1)
-    yield p
-    p.kill()
-    p.wait()
+    process = _start(["memcached"], "memcached on port 11211", _tcp("127.0.0.1", 11211))
+    yield process
+    _stop(process)
 
 
-@pytest.yield_fixture(scope="session", autouse=True)
+@pytest.fixture(scope="session", autouse=True)
 def memcached_other_port():
-    p = subprocess.Popen(
-        ["memcached", "-p5000"], stdout=subprocess.PIPE, stderr=subprocess.PIPE
-    )
-    time.sleep(0.1)
-    yield p
-    p.kill()
-    p.wait()
+    process = _start(["memcached", "-p5000"], "memcached on port 5000", _tcp("127.0.0.1", 5000))
+    yield process
+    _stop(process)
 
 
-@pytest.yield_fixture(scope="session", autouse=True)
+@pytest.fixture(scope="session", autouse=True)
 def memcached_socket():
-    p = subprocess.Popen(
-        ["memcached", "-s/tmp/memcached.sock"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+    # A previous run that died before teardown leaves the socket file behind.
+    # memcached then fails to bind.
+    _remove_socket_file()
+
+    process = _start(
+        ["memcached", "-s" + SOCKET_PATH],
+        "memcached on unix socket {}".format(SOCKET_PATH),
+        _unix(SOCKET_PATH),
     )
-    time.sleep(0.1)
-    yield p
-    p.kill()
-    p.wait()
+    yield process
+    _stop(process)
+    _remove_socket_file()
 
 
-@pytest.yield_fixture(scope="session", autouse=True)
+def _remove_socket_file():
+    try:
+        os.unlink(SOCKET_PATH)
+    except FileNotFoundError:
+        pass
+
+
+@pytest.fixture(scope="session", autouse=True)
 def memcached_ipv6():
-    p = subprocess.Popen(
-        ["memcached", "-l::1"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+    # This server needs its own port. On Linux a plain memcached binds both
+    # INADDR_ANY and IN6ADDR_ANY, so port 11211 is already taken here.
+    process = _start(
+        ["memcached", "-l::1", "-p{}".format(IPV6_PORT)],
+        "memcached on [::1]:{}".format(IPV6_PORT),
+        _tcp("::1", IPV6_PORT, socket.AF_INET6),
     )
-    time.sleep(0.1)
-    yield p
-    p.kill()
-    p.wait()
+    yield process
+    _stop(process)
+
+
+@pytest.fixture(scope="session")
+def memcached_sasl():
+    """
+    Start a memcached with SASL authentication enabled.
+
+    This fixture yields (port, username, password). It skips when memcached is
+    not built with SASL support, or when saslpasswd2 is absent from PATH.
+    Cyrus SASL needs a real user database, and saslpasswd2 is the tool that
+    writes one.
+    """
+    if shutil.which("saslpasswd2") is None:
+        pytest.skip("saslpasswd2 is not on PATH. Cannot build a SASL user database.")
+
+    username = "bmemcached_test_user"
+    password = "bmemcached_test_password"
+    # Cyrus SASL stores the user under a realm. memcached looks it up under the
+    # local hostname, so both sides must agree.
+    realm = socket.gethostname()
+
+    conf_dir = tempfile.mkdtemp(prefix="bmemcached-sasl-")
+    sasldb_path = os.path.join(conf_dir, "sasldb2")
+
+    with open(os.path.join(conf_dir, "memcached.conf"), "w") as conf:
+        conf.write(
+            "mech_list: PLAIN\n"
+            "pwcheck_method: auxprop\n"
+            "auxprop_plugin: sasldb\n"
+            "sasldb_path: {}\n".format(sasldb_path)
+        )
+
+    written = subprocess.run(
+        ["saslpasswd2", "-p", "-c", "-f", sasldb_path, "-a", "memcached", "-u", realm, username],
+        input=password.encode(),
+        capture_output=True,
+    )
+    if written.returncode != 0:
+        shutil.rmtree(conf_dir, ignore_errors=True)
+        pytest.skip(
+            "saslpasswd2 failed: {}".format(written.stderr.decode("utf8", "replace").strip())
+        )
+
+    environment = dict(os.environ, SASL_CONF_PATH=conf_dir)
+    try:
+        process = subprocess.Popen(
+            ["memcached", "-p{}".format(SASL_PORT), "-S"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=environment,
+        )
+    except OSError as error:
+        shutil.rmtree(conf_dir, ignore_errors=True)
+        pytest.skip("Cannot run memcached: {}. Is memcached on PATH?".format(error))
+
+    try:
+        _wait_until_accepting(
+            process,
+            "memcached with SASL on port {}".format(SASL_PORT),
+            _tcp("127.0.0.1", SASL_PORT),
+        )
+        yield SASL_PORT, username, password
+    finally:
+        _stop(process)
+        shutil.rmtree(conf_dir, ignore_errors=True)

--- a/test/test_distributed_client_hashing.py
+++ b/test/test_distributed_client_hashing.py
@@ -1,12 +1,93 @@
 import unittest
+
 import bmemcached
+
+
+THREE_SERVERS = ['localhost:11211', 'localhost:11212', 'localhost:11213']
 
 
 class DistributedClientHashingTest(unittest.TestCase):
     def test_get_server_is_consistent(self):
         key = 'the_key'
-        servers = ['localhost:11211', 'localhost:11212', 'localhost:11213']
 
         for _ in range(10):
-            client = bmemcached.DistributedClient(servers)
+            client = bmemcached.DistributedClient(THREE_SERVERS)
             self.assertEqual(client._get_server(key).port, 11211)
+
+    def test_same_server_list_gives_the_same_ring(self):
+        """
+        Two clients built from the same server list agree on every key.
+        """
+        first = bmemcached.DistributedClient(THREE_SERVERS)
+        second = bmemcached.DistributedClient(THREE_SERVERS)
+
+        for index in range(200):
+            key = 'key_{}'.format(index)
+            self.assertEqual(first._get_server(key).port, second._get_server(key).port)
+
+    def test_removing_a_server_moves_only_its_own_keys(self):
+        """
+        This is the property that consistent hashing exists for.
+
+        A plain modulo hash remaps almost every key when the server count
+        changes. A consistent hash ring must move only the keys that lived on
+        the server that left.
+        """
+        removed_port = 11213
+        remaining = [server for server in THREE_SERVERS if not server.endswith(str(removed_port))]
+
+        before = bmemcached.DistributedClient(THREE_SERVERS)
+        after = bmemcached.DistributedClient(remaining)
+
+        keys = ['key_{}'.format(index) for index in range(500)]
+        moved = []
+        for key in keys:
+            old_port = before._get_server(key).port
+            new_port = after._get_server(key).port
+            if old_port != new_port:
+                moved.append((key, old_port, new_port))
+
+        # No key that lived on a surviving server is allowed to move.
+        for key, old_port, new_port in moved:
+            self.assertEqual(
+                removed_port, old_port,
+                'key {} moved from {} to {}, but {} was still in the ring'.format(
+                    key, old_port, new_port, old_port))
+
+        # Every key that lived on the removed server must land somewhere else.
+        for key in keys:
+            if before._get_server(key).port == removed_port:
+                self.assertIn(after._get_server(key).port, (11211, 11212))
+
+    def test_adding_a_server_takes_keys_only_from_the_others(self):
+        """
+        An added server takes a share of the keys. No key moves between two
+        servers that were both already in the ring.
+        """
+        added_port = 11214
+        larger = THREE_SERVERS + ['localhost:{}'.format(added_port)]
+
+        before = bmemcached.DistributedClient(THREE_SERVERS)
+        after = bmemcached.DistributedClient(larger)
+
+        keys = ['key_{}'.format(index) for index in range(500)]
+        moved_to_new_server = 0
+        for key in keys:
+            old_port = before._get_server(key).port
+            new_port = after._get_server(key).port
+            if old_port == new_port:
+                continue
+            self.assertEqual(
+                added_port, new_port,
+                'key {} moved from {} to {}, but neither server is new'.format(
+                    key, old_port, new_port))
+            moved_to_new_server += 1
+
+        # The new server must actually receive keys. A ring that gave it none
+        # would pass the check above without testing anything.
+        self.assertGreater(moved_to_new_server, 0)
+
+    def test_every_server_receives_keys(self):
+        client = bmemcached.DistributedClient(THREE_SERVERS)
+        ports = {client._get_server('key_{}'.format(index)).port for index in range(500)}
+        self.assertEqual({11211, 11212, 11213}, ports)

--- a/test/test_ipv6.py
+++ b/test/test_ipv6.py
@@ -1,0 +1,42 @@
+import bmemcached
+
+from conftest import IPV6_PORT
+
+
+SERVER = '[::1]:{}'.format(IPV6_PORT)
+
+
+def test_set_and_get_over_ipv6():
+    """
+    Do a real round trip over IPv6.
+
+    test/test_server_parsing.py only parses '::1' strings. It never opens a
+    socket, so nothing proved that the IPv6 path works end to end.
+    """
+    client = bmemcached.Client(SERVER)
+    try:
+        assert client.set('ipv6_key', 'ipv6_value') is True
+        assert client.get('ipv6_key') == 'ipv6_value'
+    finally:
+        client.delete('ipv6_key')
+        client.disconnect_all()
+
+
+def test_set_multi_and_get_multi_over_ipv6():
+    client = bmemcached.Client(SERVER)
+    try:
+        assert client.set_multi({'ipv6_a': 1, 'ipv6_b': 'two'}) == []
+        assert client.get_multi(['ipv6_a', 'ipv6_b']) == {'ipv6_a': 1, 'ipv6_b': 'two'}
+    finally:
+        client.delete_multi(['ipv6_a', 'ipv6_b'])
+        client.disconnect_all()
+
+
+def test_server_reports_the_ipv6_host():
+    client = bmemcached.Client(SERVER)
+    try:
+        server = next(iter(client.servers))
+        assert server.host == '::1'
+        assert server.port == IPV6_PORT
+    finally:
+        client.disconnect_all()

--- a/test/test_sasl_integration.py
+++ b/test/test_sasl_integration.py
@@ -1,0 +1,58 @@
+import pytest
+
+import bmemcached
+from bmemcached.exceptions import MemcachedException
+
+
+def _client(memcached_sasl, username=None, password=None):
+    port, default_user, default_password = memcached_sasl
+    return bmemcached.Client(
+        '127.0.0.1:{}'.format(port),
+        default_user if username is None else username,
+        default_password if password is None else password,
+    )
+
+
+def test_authenticate_then_set_and_get(memcached_sasl):
+    """
+    Authenticate against a real SASL-enabled memcached, then do a round trip.
+
+    test/test_auth.py mocks Protocol._get_response and feeds canned bytes. It
+    covers the client state machine only. Nothing exercised a real server with
+    authentication turned on.
+    """
+    client = _client(memcached_sasl)
+    try:
+        assert client.set('sasl_key', 'sasl_value') is True
+        assert client.get('sasl_key') == 'sasl_value'
+    finally:
+        client.delete('sasl_key')
+        client.disconnect_all()
+
+
+def test_wrong_password_is_rejected(memcached_sasl):
+    """
+    A wrong password fails the operation.
+
+    memcached answers a failed SASL_AUTH with status 0x20, which the client
+    does not map to InvalidCredentials. It maps 0x08 only. The client still
+    refuses the operation, so this test asserts the base exception. The
+    mapping gap is tracked separately.
+    """
+    client = _client(memcached_sasl, password='the-wrong-password')
+    try:
+        with pytest.raises(MemcachedException) as caught:
+            client.set('sasl_key', 'sasl_value')
+        assert 'Auth failure' in str(caught.value)
+    finally:
+        client.disconnect_all()
+
+
+def test_protocol_authenticate_returns_true(memcached_sasl):
+    port, username, password = memcached_sasl
+    server = bmemcached.protocol.Protocol('127.0.0.1:{}'.format(port), username, password)
+    try:
+        assert server.authenticate(username, password) is True
+        assert server.authenticated is True
+    finally:
+        server.disconnect()


### PR DESCRIPTION
## What changed

`test/conftest.py` is rewritten. Every fixture now checks that the process
started, waits for the port with a retry loop, and uses `@pytest.fixture` in
place of the deprecated `pytest.yield_fixture`. The unix socket file is removed
before start and on teardown. The IPv6 server moves to port 5002. A new
`memcached_sasl` fixture starts memcached with SASL authentication enabled.

Three test files change or arrive:

- `test/test_ipv6.py` is new. It does a real `set`, `get`, `set_multi`, and
  `get_multi` over IPv6.
- `test/test_sasl_integration.py` is new. It authenticates against a real
  SASL-enabled server and does a `set` and a `get`.
- `test/test_distributed_client_hashing.py` gains four tests. They check the
  key-to-server mapping after a server joins and after a server leaves.

`flake.nix` builds memcached with SASL, in the same way it already builds it
with TLS. It adds `cyrus_sasl.bin` to the dev shell for `saslpasswd2`.

## Why

The fixtures started real memcached processes and never checked the result. A
missing `memcached` binary failed every test with an opaque
`ConnectionRefusedError`. A fixed `time.sleep(0.1)` made a slow start flaky. A
run that died before teardown left `/tmp/memcached.sock` behind, and the next
run then failed to bind.

Two coverage gaps were larger. The IPv6 fixture ran on every session and no
test connected to it, so nothing proved the IPv6 path worked end to end.
`test/test_auth.py` mocks `Protocol._get_response` and feeds canned bytes, so
no test ever ran against a server with authentication turned on.
`test/test_distributed_client_hashing.py` held 12 lines and asserted one key
against one server ten times. It never tested ring rebalance, which is the
property consistent hashing exists for.

## Verification

```
nix develop --command bash -c 'pytest -q'
```

Result: `271 passed`. The baseline on `main` is `261 passed`. This pull request
adds 10 tests and changes no existing count. It also removes four
`PytestDeprecationWarning` lines; one remains, from `test/test_tls.py`.

```
nix develop --command bash -c 'flake8'
```

Result: 0 errors.

The new tests, run alone:

```
nix develop --command bash -c 'pytest -q test/test_ipv6.py test/test_sasl_integration.py'
nix develop --command bash -c 'pytest -q test/test_distributed_client_hashing.py'
```

Result: `6 passed` and `5 passed`.

The skip path, with `memcached` removed from `PATH`:

```
PATH=<without the memcached directory> pytest -q test/test_ipv6.py -rs
```

Result: `3 skipped`, each with
`Cannot run memcached: [Errno 2] No such file or directory: 'memcached'. Is memcached on PATH?`
On `main` this run fails instead, with `ConnectionRefusedError`.

Stale socket recovery:

```
touch /tmp/memcached.sock
nix develop --command bash -c 'pytest -q test/test_socket.py'
```

Result: `44 passed`, and `/tmp/memcached.sock` is gone after the run. On `main`
the memcached process fails to bind.

## Risks

A reviewer must check four points.

1. **The SASL test skips in CI as things stand.** The fixture needs
   `saslpasswd2`, which Ubuntu ships in the `sasl2-bin` package, and a
   memcached built with SASL support. `.ci-before-script.sh` installs neither.
   Adding them belongs to the CI workflow issue (#271), not here. The fixture
   skips cleanly with a clear reason rather than failing. It does run and pass
   in the Nix dev shell.
2. **`flake.nix` changes the memcached build.** It adds `--enable-sasl` and
   `--enable-sasl-pwdb` next to the existing `--enable-tls`, and it adds
   `cyrus_sasl` as a build input. This forces a memcached rebuild on the first
   `nix develop` after checkout. Verified locally: `memcached --help` now lists
   `-S, --enable-sasl`, and the full suite still passes.
3. **The IPv6 fixture moved from port 11211 to port 5002.** It had to. On Linux
   a plain `memcached` binds both `INADDR_ANY` and `IN6ADDR_ANY`, so the
   `memcached_standard_port` fixture already holds 11211 and the `-l::1`
   process cannot bind it. That failure was silent before, because nothing
   checked the process and no test used the fixture.
4. **Fixed ports are still fixed.** Problem 2 in the issue describes port
   collisions between two runners on one host. This pull request does not make
   the ports dynamic. That is not in the acceptance criteria, and the test
   files hardcode `:11211` and `:5000` in many places. What did change is the
   failure mode: a collision now gives one clear skip that names the port and
   the memcached stderr, in place of an opaque error in every test.

Two findings came out of this work. Neither is folded into this pull request.

- **#283** — memcached answers a failed SASL auth with status `0x20`. The
  client maps only `0x08` to `InvalidCredentials`, so a wrong password raises
  the base `MemcachedException`. The mocked test in `test/test_auth.py` hid
  this, because it feeds `0x08` by hand.
  `test/test_sasl_integration.py::test_wrong_password_is_rejected` asserts the
  real behavior and names the issue in its docstring.
- **#284** — `test/test_tls.py:16` still uses the deprecated
  `pytest.yield_fixture`. It is outside this issue's file list.

On the related report: #250 says the unit tests do not run successfully on
Ubuntu. This pull request turns the most likely cause, a missing or slow
`memcached`, into a clear skip message rather than a wall of connection
errors. It does not confirm the original diagnosis, so I have not closed that
issue.

Closes #274


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added development support for TLS and SASL-enabled memcached environments.
  * Added integration coverage for authenticated memcached connections, including successful and failed authentication.
  * Added IPv6 integration coverage for single-key and multi-key operations.

* **Bug Fixes**
  * Improved test server startup checks and diagnostics.
  * Improved handling of active and stale Unix socket files.
  * Expanded distributed hashing validation for consistent key placement when servers change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->