### PR TITLE
ci: add Mergify merge queue

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,23 @@
+# Mergify merge queue. Docs: https://docs.mergify.com/merge-queue/
+#
+# Branch protection on `main` stays the source of truth for the merge
+# requirements (`lint` and `tests (3.12)` green). Mergify injects those
+# conditions into the queue, so this file does not repeat them.
+
+queue_rules:
+  - name: default
+    # Keep every commit. A squash breaks the conventional-commit history that
+    # the release automation reads.
+    merge_method: merge
+    update_method: rebase
+    # Stack up to 20 pull requests on one temporary branch and run the test
+    # suite once for the whole batch.
+    batch_size: 20
+    batch_max_wait_time: 5 min
+    checks_timeout: 30 min
+
+merge_protections_settings:
+  # `main` requires 0 approvals, so an explicit label is the merge gate.
+  # Without it, any green pull request from any contributor merges itself.
+  auto_merge_conditions:
+    - label = ready-to-merge


### PR DESCRIPTION
## What changed

Add `.mergify.yml`. It sets up a Mergify merge queue for `main`.

```yaml
queue_rules:
  - name: default
    merge_method: merge
    update_method: rebase
    batch_size: 20
    batch_max_wait_time: 5 min
    checks_timeout: 30 min

merge_protections_settings:
  auto_merge_conditions:
    - label = ready-to-merge
```

## Why

The queue stacks up to 20 pull requests on one temporary branch and runs the test suite once for the batch. This reduces CI minutes and keeps `main` green. If a batch fails, Mergify bisects the batch to find the guilty pull request.

The merge method is `merge`, not `squash`. A squash removes the conventional-commit history that the release automation reads.

Branch protection on `main` stays the source of truth for the merge requirements (`lint` and `tests (3.12)` green). Mergify injects those conditions into the queue, so the file does not repeat them.

## Merge gate

`main` requires 0 approvals. Without a gate, any green pull request from any contributor merges without review. The `ready-to-merge` label is that gate. A maintainer adds the label, and Mergify queues the pull request.

## Changes outside this repository

- `required_approving_review_count` on `main` is now 0.
- `lint` is now a required status check on `main`, next to `tests (3.12)`.
- The `ready-to-merge` label exists.

## Effect

Mergify reads its configuration from the default branch. The queue starts after this pull request merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project automation to streamline pull request merging.
  * Merge processing now supports queued updates, commit preservation, batching, and configured wait and check timeouts.
  * Automatic merging is restricted to changes marked as ready for merge.
  * No user-facing product features or public interfaces were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->